### PR TITLE
Docs: clarify that APP_ID is not an auth code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ESLint GitHub bot - GLaDOS
 * `PORT`: Port for web server _(default 8000)_.
 * `SECRET`: Secret setup for GitHub webhook or you generated when you created the app.
 * `PRIVATE_KEY`: the contents of the private key you downloaded after creating the app.
-* `APP_ID`: Auth token for the bot.
+* `APP_ID`: The numeric app ID
 
 ## :sunrise_over_mountains: Technical Insight
 


### PR DESCRIPTION
The app ID is a short (4-digit) number. Calling it an "Auth token" makes it sound like the ID is a secret value, but that's not the case.