### PR TITLE
Chore: remove race conditions and hardcoded timeouts

### DIFF
--- a/src/plugins/check-unit-test/index.js
+++ b/src/plugins/check-unit-test/index.js
@@ -58,7 +58,7 @@ const action = async (context) => {
         const { data: allFiles } = await github.pullRequests.getFiles(context.issue());
 
         if (!areUnitTestFilesPresent(allFiles, payload.repository.html_url)) {
-            github.issues.createComment(context.issue({
+            await github.issues.createComment(context.issue({
                 body: commentMessage(payload.sender.login)
             }));
         }

--- a/src/plugins/duplicate-comments/index.js
+++ b/src/plugins/duplicate-comments/index.js
@@ -101,12 +101,12 @@ const duplicateCheck = async (context) => {
     if (payload.issue.state === "open") {
         const allComments = await github.issues.getComments(context.issue());
 
-        processComments(allComments.data)
-            .forEach(
+        await Promise.all(processComments(allComments.data)
+            .map(
                 (comment) => github.issues.deleteComment(
                     context.repo({ id: comment.id })
                 )
-            );
+            ));
     }
 };
 

--- a/src/plugins/needs-info/index.js
+++ b/src/plugins/needs-info/index.js
@@ -46,11 +46,11 @@ const hasNeedInfoLabel = (labels) =>
  * @returns {undefined}
  * @private
  */
-const check = (context) => {
+const check = async (context) => {
     const { payload, github } = context;
 
     if (hasNeedInfoLabel(payload.issue.labels)) {
-        github.issues.createComment(context.issue({
+        await github.issues.createComment(context.issue({
             body: commentMessage(payload.issue.user.login)
         }));
     }

--- a/src/plugins/triage/index.js
+++ b/src/plugins/triage/index.js
@@ -10,9 +10,9 @@
  * @returns {undefined}
  * @private
  */
-const triage = ({ payload, github }) => {
+const triage = async ({ payload, github }) => {
     if (payload.issue.labels.length === 0) {
-        github.issues.addLabels({
+        await github.issues.addLabels({
             owner: payload.repository.owner.login,
             repo: payload.repository.name,
             number: payload.issue.number,

--- a/tests/plugins/check-unit-test/index.js
+++ b/tests/plugins/check-unit-test/index.js
@@ -64,92 +64,68 @@ describe("check-unit-test", () => {
     });
 
     describe("pull request opened", () => {
-        test("Add message if the there are no test files", (done) => {
+        test("Add message if the there are no test files", async () => {
             mockPrWithFiles("src/make.js");
-            emitBotEvent(bot, {
+            await emitBotEvent(bot, {
                 action: "opened",
                 title: "New: some work done"
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            });
+
+            expect(nockScope.isDone()).toBeTruthy();
         });
 
-        test("Do not add message if the test folder is present", (done) => {
+        test("Do not add message if the test folder is present", async () => {
             mockPrWithFiles("src/tests/make.js");
-            emitBotEvent(bot, {
+            await emitBotEvent(bot, {
                 action: "opened",
                 title: "New: some work done"
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).not.toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            });
+
+            expect(nockScope.isDone()).not.toBeTruthy();
         });
 
-        test("Add message if the test folder is not present tho a file with named test is", (done) => {
+        test("Add message if the test folder is not present tho a file with named test is", async () => {
             mockPrWithFiles("src/lib/test.js");
-            emitBotEvent(bot, {
+            await emitBotEvent(bot, {
                 action: "opened",
                 title: "New: some work done"
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            });
+
+            expect(nockScope.isDone()).toBeTruthy();
         });
 
-        test("Do not add message if the test files are not present and commit is chore", (done) => {
+        test("Do not add message if the test files are not present and commit is chore", async () => {
             mockPrWithFiles("src/make.js");
-            emitBotEvent(bot, {
+            await emitBotEvent(bot, {
                 action: "opened",
                 title: "Chore: some work done"
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).not.toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            });
+
+            expect(nockScope.isDone()).not.toBeTruthy();
         });
     });
 
     describe("pull request reopened", () => {
-        test("Add message if the there are no test files", (done) => {
+        test("Add message if the there are no test files", async () => {
             mockPrWithFiles("src/make.js");
-            emitBotEvent(bot, {
+            await emitBotEvent(bot, {
                 action: "reopened",
                 title: "New: some work done"
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            });
+
+            expect(nockScope.isDone()).toBeTruthy();
         });
     });
 
     describe("pull request synchronize", () => {
-        test("Add message if the there are no test files", (done) => {
+        test("Add message if the there are no test files", async () => {
             mockPrWithFiles("src/make.js");
-            emitBotEvent(bot, {
+            await emitBotEvent(bot, {
                 action: "synchronize",
                 title: "New: some work done"
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            });
+
+            expect(nockScope.isDone()).toBeTruthy();
         });
     });
 });

--- a/tests/plugins/commit-message/index.js
+++ b/tests/plugins/commit-message/index.js
@@ -75,40 +75,40 @@ describe("commit-message", () => {
 
     ["opened", "reopened", "synchronize", "edited"].forEach((action) => {
         describe(`pull request ${action}`, () => {
-            test("Posts failure status if commit message is not correct", () => {
+            test("Posts failure status if commit message is not correct", async () => {
                 mockSingleCommitWithMessage("non standard commit message");
 
                 const nockScope = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/first-sha", (req) => req.state === "failure")
                     .reply(201);
 
-                return emitBotEvent(bot, { action })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action });
+                expect(nockScope.isDone()).toBeTruthy();
             });
 
-            test("Posts success status if commit message is correct", () => {
+            test("Posts success status if commit message is correct", async () => {
                 mockSingleCommitWithMessage("New: standard commit message");
 
                 const nockScope = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/first-sha", (req) => req.state === "success")
                     .reply(201);
 
-                return emitBotEvent(bot, { action })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action });
+                expect(nockScope.isDone()).toBeTruthy();
             });
 
-            test("Posts failure status if the commit message is longer than 72 chars", () => {
+            test("Posts failure status if the commit message is longer than 72 chars", async () => {
                 mockSingleCommitWithMessage("New: standard commit message very very very long message and its beond 72");
 
                 const nockScope = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/first-sha", (req) => req.state === "failure")
                     .reply(201);
 
-                return emitBotEvent(bot, { action })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action });
+                expect(nockScope.isDone()).toBeTruthy();
             });
 
-            test("Posts success status if the commit message is longer than 72 chars after the newline", () => {
+            test("Posts success status if the commit message is longer than 72 chars after the newline", async () => {
                 mockSingleCommitWithMessage(
                     `New: foo\n\n${"A".repeat(72)}`
                 );
@@ -117,41 +117,41 @@ describe("commit-message", () => {
                     .post("/repos/test/repo-test/statuses/first-sha", (req) => req.state === "success")
                     .reply(201);
 
-                return emitBotEvent(bot, { action })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action });
+                expect(nockScope.isDone()).toBeTruthy();
             });
 
-            test("Posts success status if there are multiple commit messages and the title is valid", () => {
+            test("Posts success status if there are multiple commit messages and the title is valid", async () => {
                 mockMultipleCommits();
 
                 const nockScope = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/second-sha", (req) => req.state === "success")
                     .reply(201);
 
-                return emitBotEvent(bot, { action, pull_request: { number: 1, title: "Update: foo" } })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action, pull_request: { number: 1, title: "Update: foo" } });
+                expect(nockScope.isDone()).toBeTruthy();
             });
 
-            test("Posts failure status if there are multiple commit messages and the title is invalid", () => {
+            test("Posts failure status if there are multiple commit messages and the title is invalid", async () => {
                 mockMultipleCommits();
 
                 const nockScope = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/second-sha", (req) => req.state === "failure")
                     .reply(201);
 
-                return emitBotEvent(bot, { action, pull_request: { number: 1, title: "foo" } })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action, pull_request: { number: 1, title: "foo" } });
+                expect(nockScope.isDone()).toBeTruthy();
             });
 
-            test("Posts failure status if there are multiple commit messages and the title is too long", () => {
+            test("Posts failure status if there are multiple commit messages and the title is too long", async () => {
                 mockMultipleCommits();
 
                 const nockScope = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/second-sha", (req) => req.state === "failure")
                     .reply(201);
 
-                return emitBotEvent(bot, { action, pull_request: { number: 1, title: `Update: ${"A".repeat(72)}` } })
-                    .then(() => expect(nockScope.isDone()).toBeTruthy());
+                await emitBotEvent(bot, { action, pull_request: { number: 1, title: `Update: ${"A".repeat(72)}` } });
+                expect(nockScope.isDone()).toBeTruthy();
             });
         });
     });

--- a/tests/plugins/duplicate-comments/index.js
+++ b/tests/plugins/duplicate-comments/index.js
@@ -66,56 +66,41 @@ describe("duplicate-comments", () => {
         nock.cleanAll();
     });
 
-    const mockDelteComment = (id) => {
+    const mockDeleteComment = (id) => {
         nockScope = nock("https://api.github.com")
             .delete(`/repos/test/repo-test/issues/comments/${id}`)
             .reply(201);
     };
 
     describe("issue comment created", () => {
-        test("Removes the duplicate comment of the bot", (done) => {
+        test("Removes the duplicate comment of the bot", async () => {
             mockComments([
                 createFakeComment(4, "test [//]: # (test)", "Bot"),
                 createFakeComment(5, "test [//]: # (test)", "Bot")
             ]);
-            mockDelteComment(4);
-            emitBotEvent(bot)
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            mockDeleteComment(4);
+            await emitBotEvent(bot);
+            expect(nockScope.isDone()).toBeTruthy();
         });
 
-        test("Do not remove any comment if no bot comment is repeated", (done) => {
+        test("Do not remove any comment if no bot comment is repeated", async () => {
             mockComments([
                 createFakeComment(4, "test [//]: # (test)", "Bot"),
                 createFakeComment(5, "test [//]: # (test-1)", "Bot")
             ]);
-            mockDelteComment(4);
-            emitBotEvent(bot)
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).not.toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            mockDeleteComment(4);
+            await emitBotEvent(bot);
+            expect(nockScope.isDone()).not.toBeTruthy();
         });
 
-        test("Do not remove any comment even if non bot comment are repeated", (done) => {
+        test("Do not remove any comment even if non bot comment are repeated", async () => {
             mockComments([
                 createFakeComment(4, "test [//]: # (test)", "user-x"),
                 createFakeComment(5, "test [//]: # (test)", "user-x")
             ]);
-            mockDelteComment(4);
-            emitBotEvent(bot)
-                .then(() => {
-                    setTimeout(() => {
-                        expect(nockScope.isDone()).not.toBeTruthy();
-                        done();
-                    }, 1000);
-                });
+            mockDeleteComment(4);
+            await emitBotEvent(bot);
+            expect(nockScope.isDone()).not.toBeTruthy();
         });
     });
 });

--- a/tests/plugins/needs-info/index.js
+++ b/tests/plugins/needs-info/index.js
@@ -28,8 +28,8 @@ describe("needs-info", () => {
     });
 
     describe("issue labeled", () => {
-        test("Adds the comment if there needs info is added", (done) => {
-            bot.receive({
+        test("Adds the comment if there needs info is added", async () => {
+            await bot.receive({
                 event: "issues",
                 payload: {
                     action: "labeled",
@@ -54,17 +54,13 @@ describe("needs-info", () => {
                         }
                     }
                 }
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(issueCommentReq.isDone()).toBeTruthy();
-                        done();
-                    }, 50);
-                });
+            });
+
+            expect(issueCommentReq.isDone()).toBeTruthy();
         });
 
-        test("Do not add the comment if needs label label is not present", (done) => {
-            bot.receive({
+        test("Do not add the comment if needs label label is not present", async () => {
+            await bot.receive({
                 event: "issues",
                 payload: {
                     action: "labeled",
@@ -89,13 +85,9 @@ describe("needs-info", () => {
                         }
                     }
                 }
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(issueCommentReq.isDone()).not.toBeTruthy();
-                        done();
-                    }, 50);
-                });
+            });
+
+            expect(issueCommentReq.isDone()).not.toBeTruthy();
         });
     });
 });

--- a/tests/plugins/triage/index.js
+++ b/tests/plugins/triage/index.js
@@ -21,7 +21,7 @@ describe("triage", () => {
     });
 
     describe("issue opened", () => {
-        test("Adds the label if there are no labels present", (done) => {
+        test("Adds the label if there are no labels present", async () => {
             const issueLabelReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels", (body) => {
                     expect(body).toContain("triage");
@@ -29,7 +29,7 @@ describe("triage", () => {
                 })
                 .reply(200);
 
-            bot.receive({
+            await bot.receive({
                 event: "issues",
                 payload: {
                     action: "opened",
@@ -47,21 +47,17 @@ describe("triage", () => {
                         }
                     }
                 }
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(issueLabelReq.isDone()).toBeTruthy();
-                        done();
-                    }, 50);
-                });
+            });
+
+            expect(issueLabelReq.isDone()).toBeTruthy();
         });
 
-        test("Do not add the label if already present", (done) => {
+        test("Do not add the label if already present", async () => {
             const issueLabelReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels")
                 .reply(200);
 
-            bot.receive({
+            await bot.receive({
                 event: "issues",
                 payload: {
                     action: "opened",
@@ -81,18 +77,14 @@ describe("triage", () => {
                         }
                     }
                 }
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(issueLabelReq.isDone()).not.toBeTruthy();
-                        done();
-                    }, 50);
-                });
+            });
+
+            expect(issueLabelReq.isDone()).not.toBeTruthy();
         });
     });
 
     describe("issue reopened", () => {
-        test("Adds the label if there are no labels present", (done) => {
+        test("Adds the label if there are no labels present", async () => {
             const issueLabelReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels", (body) => {
                     expect(body).toContain("triage");
@@ -100,7 +92,7 @@ describe("triage", () => {
                 })
                 .reply(200);
 
-            bot.receive({
+            await bot.receive({
                 event: "issues",
                 payload: {
                     action: "reopened",
@@ -118,21 +110,17 @@ describe("triage", () => {
                         }
                     }
                 }
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(issueLabelReq.isDone()).toBeTruthy();
-                        done();
-                    }, 50);
-                });
+            });
+
+            expect(issueLabelReq.isDone()).toBeTruthy();
         });
 
-        test("Do not add the label if already present", (done) => {
+        test("Do not add the label if already present", async () => {
             const issueLabelReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels")
                 .reply(200);
 
-            bot.receive({
+            await bot.receive({
                 event: "issues",
                 payload: {
                     action: "reopened",
@@ -152,13 +140,9 @@ describe("triage", () => {
                         }
                     }
                 }
-            })
-                .then(() => {
-                    setTimeout(() => {
-                        expect(issueLabelReq.isDone()).not.toBeTruthy();
-                        done();
-                    }, 50);
-                });
+            });
+
+            expect(issueLabelReq.isDone()).not.toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
This updates all the plugins to return promises, rather than starting asynchronous events without listening for results. It also updates the tests to wait for those promises rather than waiting for a hardcoded delay.