### PR TITLE
Update: disable experimental plugins by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Plugins are the core part of the bot. They are standalone pieces which listen on
 
 _Note: All plugin names marked with `*` are experimental._
 
-#### How to disable a plugin
+#### Adding plugins
 
-Works need to be done in this area but for now just comment the plugin which you want to disable inside `src/plugins/index` file.
+To add a plugin:
+
+1. Create the plugin as a new file in `src/plugins`.
+1. Add the plugin to the list in `src/plugins/index.js`.
+1. Add the plugin to the list `src/app.js` to enable it by default.

--- a/src/app.js
+++ b/src/app.js
@@ -13,13 +13,15 @@ const bot = probot({
     cert: process.env.PRIVATE_KEY || "", // required
     id: process.env.APP_ID || "" // required
 });
-const disabledPlugins = [
-    "prReadyToMerge"
-];
+const enabledPlugins = new Set([
+    "commitMessage",
+    "needsInfo",
+    "triage"
+]);
 
-// load all the plugins from inside plugins folder except the one which are disabled
+// load all the enabled plugins from inside plugins folder
 Object.keys(plugins)
-    .filter((pluginId) => !disabledPlugins.includes(pluginId))
+    .filter((pluginId) => enabledPlugins.has(pluginId))
     .forEach((pluginId) => bot.load(plugins[pluginId]));
 
 // start the server


### PR DESCRIPTION
I want it to be as easy as possible to replace the current version of `eslintbot` with this bot, so this PR disables the experimental plugins by default so that we can replicate the current `eslintbot` behavior. I think we can reenable the experimental plugins after we resolve design issues like #15 and #22.