### PR TITLE
New: add release-issues plugin (refs #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The bot can perform the following tasks:
 * **Triage** - adds the "triage" label to newly-created issues which don't have labels.
 * **Commit message check** - adds a status check to pull requests to verify that they follow ESLint's [pull request guidelines](https://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes)
 * **Needs info** - adds a comment to issues requesting more information when a maintainer adds the `needs info` label.
+* **Release issues** - creates a new issue with the `release` label scheduled two weeks later, after another release issue is closed.
 * **PR ready to merge** (experimental) - adds a label to all PRs which are "ready to merge", defined by the following criteria:
     * At least one review is approved.
     * Build status is `success`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "repository": "eslint/eslint-github-bot",
   "bugs": "https://github.com/eslint/eslint-github-bot/issues/",
   "dependencies": {
+    "moment": "^2.19.1",
     "probot": "^3.0.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -28,7 +28,8 @@ const bot = probot({
 const enabledPlugins = new Set([
     "commitMessage",
     "needsInfo",
-    "triage"
+    "triage",
+    "releaseIssues"
 ]);
 
 // load all the enabled plugins from inside plugins folder

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -7,5 +7,6 @@ module.exports = {
     duplicateComments: require("./duplicate-comments"),
     prReadyToMerge: require("./pr-ready-to-merge"),
     needsInfo: require("./needs-info"),
-    triage: require("./triage")
+    triage: require("./triage"),
+    releaseIssues: require("./release-issues")
 };

--- a/src/plugins/release-issues/index.js
+++ b/src/plugins/release-issues/index.js
@@ -63,7 +63,7 @@ async function handleIssueClosed(context) {
         context.repo({
             title: newIssueTitle,
             body: newIssueBody,
-            labels: [LABEL_NAME]
+            labels: [LABEL_NAME, "tsc agenda"]
         })
     );
 }

--- a/src/plugins/release-issues/index.js
+++ b/src/plugins/release-issues/index.js
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Creates a new issue with the "release" label if the old one is closed
+ * @author Teddy Katz
+ */
+
+const moment = require("moment");
+
+const LABEL_NAME = "release";
+
+const ISSUE_TITLE_FORMAT = "[Scheduled release for ]MMMM Do, YYYY";
+
+const getIssueBody = (releaseDate) => `
+
+The scheduled release on ${releaseDate.format("dddd, MMMM Do, YYYY")} is assigned to:
+
+* (needs volunteers)
+* (needs volunteers)
+
+Please use this issue to document how the release went, any problems during the release, and anything the team might want to know about the release process. This issue should be closed after all patch releases have been completed (or there was no patch release needed).
+
+Resources:
+
+* [Release guidelines](https://eslint.org/docs/maintainer-guide/releases)
+
+`.trim();
+
+module.exports = (robot) => {
+    robot.on("issues.closed", async (context) => {
+        // If the issue does not have the "release" label, skip it.
+        if (!context.payload.issue.labels.some((label) => label.name === LABEL_NAME)) {
+            return;
+        }
+
+        const issueEvents = await context.github.issues.getEvents(
+            context.issue({
+                per_page: 100,
+                issue_number: context.issue().number
+            })
+        ).then((res) => res.data);
+
+        // If the issue was previously closed and then reopened, skip it.
+        if (issueEvents.filter((eventObj) => eventObj.event === "closed").length > 1) {
+            return;
+        }
+
+        const oldReleaseDate = moment.utc(context.payload.issue.title, ISSUE_TITLE_FORMAT, true);
+
+        // If the issue title can't be parsed as a date, skip it.
+        if (!oldReleaseDate.isValid()) {
+            return;
+        }
+
+        const newReleaseDate = oldReleaseDate.clone().add({ weeks: 2 });
+
+        const newIssueTitle = newReleaseDate.format(ISSUE_TITLE_FORMAT);
+        const newIssueBody = getIssueBody(newReleaseDate);
+
+        // Create a new issue with a date 2 weeks in the future.
+        await context.github.issues.create(
+            context.repo({
+                title: newIssueTitle,
+                body: newIssueBody,
+                labels: [LABEL_NAME]
+            })
+        );
+    });
+};

--- a/tests/plugins/release-issues/index.js
+++ b/tests/plugins/release-issues/index.js
@@ -1,0 +1,110 @@
+const { releaseIssues } = require("../../../src/plugins/index");
+const nock = require("nock");
+const probot = require("probot");
+const GitHubApi = require("github");
+
+describe("release-issues", () => {
+    let issueWasCreated;
+    let issue;
+
+    function runBot({ issueTitle, labelNames, eventTypes }) {
+        issueWasCreated = false;
+
+        const bot = probot.createRobot({
+            id: "test",
+            cert: "test",
+            cache: {
+                wrap: () => Promise.resolve({ data: { token: "test" } })
+            }
+        });
+        bot.auth = () => new GitHubApi();
+        releaseIssues(bot);
+
+        nock("https://api.github.com")
+            .get("/repos/test/repo-test/issues/1/events?per_page=100")
+            .reply(200, eventTypes.map((type) => ({ event: type })));
+
+        nock("https://api.github.com")
+            .post("/repos/test/repo-test/issues")
+            .reply(200, (uri, requestBody) => {
+                issueWasCreated = true;
+                issue = JSON.parse(requestBody);
+                return {};
+            });
+
+        return bot.receive({
+            event: "issues",
+            payload: {
+                installation: {
+                    id: 1
+                },
+                action: "closed",
+                issue: {
+                    number: 1,
+                    title: issueTitle,
+                    labels: labelNames.map((name) => ({ name }))
+                },
+                repository: {
+                    owner: {
+                        login: "test"
+                    },
+                    name: "repo-test"
+                }
+            }
+        });
+    }
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    describe("when an issue does not have the release label", () => {
+        test("ignores the issue", async () => {
+            await runBot({
+                issueTitle: "Scheduled release for October 27th, 2017",
+                labelNames: ["foo"],
+                eventTypes: ["closed"]
+            });
+
+            expect(issueWasCreated).toBe(false);
+        });
+    });
+
+    describe("when an issue has already been closed and reopened", () => {
+        test("ignores the issue", async () => {
+            await runBot({
+                issueTitle: "Scheduled release for October 27th, 2017",
+                labelNames: ["release"],
+                eventTypes: ["foo", "closed", "reopened", "closed"]
+            });
+
+            expect(issueWasCreated).toBe(false);
+        });
+    });
+
+    describe("when an issue has an invalid title", () => {
+        test("ignores the issue", async () => {
+            await runBot({
+                issueTitle: "Foo bar!",
+                labelNames: ["release"],
+                eventTypes: ["closed"]
+            });
+
+            expect(issueWasCreated).toBe(false);
+        });
+    });
+
+    describe("when an issue has a parseable title, has the release label, and has never been closed", () => {
+        test("creates a new issue", async () => {
+            await runBot({
+                issueTitle: "Scheduled release for October 27th, 2017",
+                labelNames: ["release"],
+                eventTypes: ["closed"]
+            });
+
+            expect(issueWasCreated).toBe(true);
+            expect(issue.title).toBe("Scheduled release for November 10th, 2017");
+            expect(issue.body.startsWith("The scheduled release on Friday, November 10th, 2017")).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Whenever an issue with the `release` label is closed for the first time, the bot parses a date out of the title and creates a new issue with the `release` label, the standard release issue text, and a date two weeks after the previous issue.