### PR TITLE
Fix: error when fetching team members for TSC meeting issue

### DIFF
--- a/src/plugins/recurring-issues/index.js
+++ b/src/plugins/recurring-issues/index.js
@@ -52,7 +52,7 @@ async function getTeamMembers({ github, organizationName, teamName }) {
 
     return Promise.all(teamMembers.map(async member => ({
         login: member.login,
-        name: await github.users.getById({ id: member.id }).then(res => res.data[0].name)
+        name: await github.users.getById({ id: member.id }).then(res => res.data.name)
     })));
 }
 

--- a/tests/plugins/recurring-issues/index.js
+++ b/tests/plugins/recurring-issues/index.js
@@ -69,21 +69,17 @@ describe("recurring-issues", () => {
 
         nock("https://api.github.com")
             .get("/user/1")
-            .reply(200, [
-                {
-                    login: "user1",
-                    name: "User One"
-                }
-            ]);
+            .reply(200, {
+                login: "user1",
+                name: "User One"
+            });
 
         nock("https://api.github.com")
             .get("/user/2")
-            .reply(200, [
-                {
-                    login: "user2",
-                    name: "User Two"
-                }
-            ]);
+            .reply(200, {
+                login: "user2",
+                name: "User Two"
+            });
 
         return bot.receive({
             event: "issues",


### PR DESCRIPTION
This fixes an issue where the response shape that the bot expected did
not match the response that GitHub actually returns. This caused the bot
to throw an error rather than posting a new TSC meeting issue earlier
today.