### PR TITLE
Fix: avoid adding `triage` when an issue already has labels (fixes #38)

### DIFF
--- a/tests/plugins/triage/index.js
+++ b/tests/plugins/triage/index.js
@@ -26,9 +26,15 @@ describe("triage", () => {
 
     describe("issue opened", () => {
         test("Adds the label if there are no labels present", async() => {
-            const issueLabelReq = nock("https://api.github.com")
+            const issueLabelGetReq = nock("https://api.github.com")
+                .get("/repos/test/repo-test/issues/1")
+                .reply(200, {
+                    labels: []
+                });
+
+            const issueLabelPostReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels", body => {
-                    expect(body).toContain("triage");
+                    expect(body).toEqual(["triage"]);
                     return true;
                 })
                 .reply(200);
@@ -53,11 +59,17 @@ describe("triage", () => {
                 }
             });
 
-            expect(issueLabelReq.isDone()).toBeTruthy();
+            expect(issueLabelGetReq.isDone()).toBeTruthy();
+            expect(issueLabelPostReq.isDone()).toBeTruthy();
         });
 
-        test("Do not add the label if already present", async() => {
-            const issueLabelReq = nock("https://api.github.com")
+        test("Does not add the label if already present in the initial webhook event", async() => {
+            const issueLabelGetReq = nock("https://api.github.com")
+                .get("/repos/test/repo-test/issues/1")
+                .reply(200, {
+                    labels: [{ name: "triage" }]
+                });
+            const issueLabelPostReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels")
                 .reply(200);
 
@@ -83,15 +95,53 @@ describe("triage", () => {
                 }
             });
 
-            expect(issueLabelReq.isDone()).not.toBeTruthy();
+            expect(issueLabelGetReq.isDone()).toBe(false);
+            expect(issueLabelPostReq.isDone()).toBe(false);
+        });
+
+        test("Does not add the label if already present when the issue is fetched", async() => {
+            const issueLabelGetReq = nock("https://api.github.com")
+                .get("/repos/test/repo-test/issues/1")
+                .reply(200, {
+                    labels: [{ name: "triage" }]
+                });
+            const issueLabelPostReq = nock("https://api.github.com")
+                .post("/repos/test/repo-test/issues/1/labels")
+                .reply(200);
+
+            await bot.receive({
+                event: "issues",
+                payload: {
+                    action: "opened",
+                    installation: {
+                        id: 1
+                    },
+                    issue: {
+                        labels: [],
+                        number: 1
+                    },
+                    repository: {
+                        name: "repo-test",
+                        owner: {
+                            login: "test"
+                        }
+                    }
+                }
+            });
+
+            expect(issueLabelGetReq.isDone()).toBe(true);
+            expect(issueLabelPostReq.isDone()).toBe(false);
         });
     });
 
     describe("issue reopened", () => {
         test("Adds the label if there are no labels present", async() => {
-            const issueLabelReq = nock("https://api.github.com")
+            const issueLabelGetReq = nock("https://api.github.com")
+                .get("/repos/test/repo-test/issues/1")
+                .reply(200, { labels: [] });
+            const issueLabelPostReq = nock("https://api.github.com")
                 .post("/repos/test/repo-test/issues/1/labels", body => {
-                    expect(body).toContain("triage");
+                    expect(body).toEqual(["triage"]);
                     return true;
                 })
                 .reply(200);
@@ -116,7 +166,8 @@ describe("triage", () => {
                 }
             });
 
-            expect(issueLabelReq.isDone()).toBeTruthy();
+            expect(issueLabelGetReq.isDone()).toBe(true);
+            expect(issueLabelPostReq.isDone()).toBe(true);
         });
 
         test("Do not add the label if already present", async() => {


### PR DESCRIPTION
As suggested in https://github.com/eslint/eslint-github-bot/issues/38, this updates the bot to make an additional request to verify that an issue has no labels before adding the `triage` label.