### PR TITLE
Chore: make status check capitalization consistent

### DIFF
--- a/src/plugins/release-monitor/index.js
+++ b/src/plugins/release-monitor/index.js
@@ -72,7 +72,7 @@ function createStatusOnPR({ context, state, sha, description }) {
             state,
             target_url: "",
             description,
-            context: "Release monitor"
+            context: "release-monitor"
         })
     );
 }


### PR DESCRIPTION
This updates the status check name for `release-monitor` to be in kebab-case, which is consistent with our other status checks (such as `commit-message` and the CI checks).