### PR TITLE
Update: make pending release-monitor status checks link to the release issue

### DIFF
--- a/src/plugins/release-monitor/index.js
+++ b/src/plugins/release-monitor/index.js
@@ -62,15 +62,16 @@ function getAllOpenPRs(context) {
  * @param {string} state - state can be either success or failure
  * @param {string} sha - sha for the commit
  * @param {string} description - description for the status
+ * @param {string} targetUrl The URL that the status should link to
  * @returns {Promise} Resolves when the status is created on the PR
  * @private
  */
-function createStatusOnPR({ context, state, sha, description }) {
+function createStatusOnPR({ context, state, sha, description, targetUrl }) {
     return context.github.repos.createStatus(
         context.repo({
             sha,
             state,
-            target_url: "",
+            target_url: targetUrl || "",
             description,
             context: "Release monitor"
         })
@@ -81,15 +82,17 @@ function createStatusOnPR({ context, state, sha, description }) {
  * Create success status on the PR
  * @param {Object} context - probot context object
  * @param {string} sha - sha for the commit
+ * @param {string|null} targetUrl A link to the pending release issue, if it exists
  * @returns {Promise} Resolves when the status is created on the PR
  * @private
  */
-function createSuccessPRStatus({ context, sha, description = "No patch release is pending" }) {
+function createSuccessPRStatus({ context, sha, description = "No patch release is pending", targetUrl }) {
     return createStatusOnPR({
         context,
         state: "success",
         description,
-        sha
+        sha,
+        targetUrl
     });
 }
 
@@ -97,15 +100,17 @@ function createSuccessPRStatus({ context, sha, description = "No patch release i
  * Create pending status on the PR
  * @param {Object} context - probot context object
  * @param {string} sha - sha for the commit
+ * @param {string|null} targetUrl A link to the pending release issue, if it exists
  * @returns {Promise} Resolves when the status is created on the PR
  * @private
  */
-function createPendingPRStatus({ context, sha }) {
+function createPendingPRStatus({ context, sha, targetUrl }) {
     return createStatusOnPR({
         context,
         state: "pending",
         description: "A patch release is pending",
-        sha
+        sha,
+        targetUrl
     });
 }
 
@@ -129,10 +134,11 @@ function getAllCommitForPR(context, number) {
  * @param {Object} context - probot context object
  * @param {Array<Object>} prs - Collection of prs
  * @param {boolean} isSuccess - to create a success status
+ * @param {string|null} releaseIssueUrl A link to the pending release issue, if it exists
  * @returns {Promise} Resolves when the status is created on the PRs
  * @private
  */
-async function createStatusOnPRs({ context, prs, isSuccess }) {
+async function createStatusOnPRs({ context, prs, isSuccess, releaseIssueUrl }) {
     const statusFunc = isSuccess ? createSuccessPRStatus : createPendingPRStatus;
 
     await Promise.all(prs.map(async pr => {
@@ -140,7 +146,8 @@ async function createStatusOnPRs({ context, prs, isSuccess }) {
 
         await statusFunc({
             context,
-            sha: pluckLatestCommitSha(allCommits)
+            sha: pluckLatestCommitSha(allCommits),
+            targetUrl: releaseIssueUrl
         });
     }));
 }
@@ -149,16 +156,18 @@ async function createStatusOnPRs({ context, prs, isSuccess }) {
  * Get all the commits for a PR
  * @param {Object} context - probot context object
  * @param {boolean} isSuccess - to create a success status
+ * @param {string|null} releaseIssueUrl A link to the pending release issue, if it exists
  * @returns {Promise} Resolves when the status is created on the PR
  * @private
  */
-async function createStatusOnAllPRs({ context, isSuccess }) {
+async function createStatusOnAllPRs({ context, isSuccess, releaseIssueUrl }) {
     const { data: allOpenPrs } = await getAllOpenPRs(context);
 
     return createStatusOnPRs({
         context,
         prs: allOpenPrs,
-        isSuccess
+        isSuccess,
+        releaseIssueUrl
     });
 }
 
@@ -220,7 +229,8 @@ async function issueLabeledHandler(context) {
         await createStatusOnPRs({
             context,
             prs: await getNonSemverPatchPRs(context),
-            isSuccess: false
+            isSuccess: false,
+            releaseIssueUrl: context.payload.issue.html_url
         });
     }
 }
@@ -239,7 +249,8 @@ async function issueCloseHandler(context) {
         // remove pending status and add success status on all PRs
         await createStatusOnAllPRs({
             context,
-            isSuccess: true
+            isSuccess: true,
+            releaseIssueUrl: null
         });
     }
 }
@@ -257,7 +268,7 @@ async function prOpenHandler(context) {
      * false: add success status to pr
      * true: add failure message if its not a fix or doc pr else success
      */
-    const { data: releaseIssue } = await context.github.issues.getForRepo(
+    const { data: releaseIssues } = await context.github.issues.getForRepo(
         context.repo({
             labels: `${RELEASE_LABEL},${POST_RELEASE_LABEL}`
         })
@@ -266,14 +277,15 @@ async function prOpenHandler(context) {
     const allCommits = await context.github.pullRequests.getCommits(context.issue());
     const isSemverPatchPr = isMessageValidForPatchRelease(getCommitMessageForPR(allCommits, context.payload.pull_request));
     const statusFunc =
-        releaseIssue.length === 0 || isSemverPatchPr
+        releaseIssues.length === 0 || isSemverPatchPr
             ? createSuccessPRStatus
             : createPendingPRStatus;
 
     await statusFunc({
         context,
         sha: pluckLatestCommitSha(allCommits),
-        description: isSemverPatchPr ? "This change is semver-patch" : void 0
+        description: isSemverPatchPr ? "This change is semver-patch" : void 0,
+        targetUrl: releaseIssues.length && releaseIssues[0].html_url
     });
 }
 

--- a/tests/plugins/release-monitor/index.js
+++ b/tests/plugins/release-monitor/index.js
@@ -43,17 +43,18 @@ function mockAllOpenPrWithCommits(mockData = []) {
 }
 
 /**
- * Asserts that the state value is pending
+ * Asserts that the state value is pending and that it links to an issue.
  * @param {string} _ - ignored param
  * @param {string} payload - payload sent ot the API
  * @returns {undefined}
  * @private
  */
-function assertPendingStatus(_, payload) {
+function assertPendingStatusWithIssueLink(_, payload) {
     const data = JSON.parse(payload);
 
     expect(data.state).toBe("pending");
     expect(data.description).toBe("A patch release is pending");
+    expect(data.target_url).toBe("https://github.com/test/repo-test/issues/1");
 }
 
 /**
@@ -68,6 +69,7 @@ function assertSuccessStatusWithNoPendingRelease(_, payload) {
 
     expect(JSON.parse(payload).state).toBe("success");
     expect(data.description).toBe("No patch release is pending");
+    expect(data.target_url).toBe("");
 }
 
 /**
@@ -181,7 +183,7 @@ describe("release-monitor", () => {
             ]);
             const newPrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/111")
-                .reply(200, assertPendingStatus);
+                .reply(200, assertPendingStatusWithIssueLink);
 
             const fixPrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/222")
@@ -219,7 +221,8 @@ describe("release-monitor", () => {
                                 name: POST_RELEASE_LABEL
                             }
                         ],
-                        number: 5
+                        number: 1,
+                        html_url: "https://github.com/test/repo-test/issues/1"
                     },
                     label: {
                         name: POST_RELEASE_LABEL
@@ -490,7 +493,8 @@ describe("release-monitor", () => {
                                 name: RELEASE_LABEL
                             }
                         ],
-                        number: 5
+                        number: 5,
+                        html_url: "https://github.com/test/repo-test/issues/1"
                     },
                     repository: {
                         name: "repo-test",
@@ -557,7 +561,8 @@ describe("release-monitor", () => {
                                 name: "test"
                             }
                         ],
-                        number: 5
+                        number: 5,
+                        html_url: "https://github.com/test/repo-test/issues/5"
                     },
                     repository: {
                         name: "repo-test",
@@ -599,11 +604,15 @@ describe("release-monitor", () => {
 
                 nock("https://api.github.com")
                     .get("/repos/test/repo-test/issues?labels=release%2Cpost-release")
-                    .reply(200, [{}]);
+                    .reply(200, [
+                        {
+                            html_url: "https://github.com/test/repo-test/issues/1"
+                        }
+                    ]);
 
                 const newPrStatus = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/111")
-                    .reply(200, assertPendingStatus);
+                    .reply(200, assertPendingStatusWithIssueLink);
 
                 await bot.receive({
                     event: "pull_request",
@@ -646,7 +655,11 @@ describe("release-monitor", () => {
 
                 nock("https://api.github.com")
                     .get("/repos/test/repo-test/issues?labels=release%2Cpost-release")
-                    .reply(200, [{}]);
+                    .reply(200, [
+                        {
+                            html_url: "https://github.com/test/repo-test/issues/1"
+                        }
+                    ]);
 
                 const newPrStatus = nock("https://api.github.com")
                     .post("/repos/test/repo-test/statuses/111")


### PR DESCRIPTION
This updates status checks created by the `release-monitor` plugin to link to the pending release issue, to give the user a better idea about what the plugin is doing.