### PR TITLE
Fix: make release-monitor statuses consistent (fixes #49)

### DIFF
--- a/src/plugins/release-monitor/index.js
+++ b/src/plugins/release-monitor/index.js
@@ -146,7 +146,13 @@ async function createAppropriateStatusForPR({ context, pr, pendingReleaseIssueUr
 async function createStatusOnAllPRs({ context, pendingReleaseIssueUrl }) {
     const { data: allOpenPrs } = await getAllOpenPRs(context);
 
-    return Promise.all(allOpenPrs.map(pr => createAppropriateStatusForPR({ context, pr, pendingReleaseIssueUrl })));
+    return Promise.all(allOpenPrs.map(pr =>
+        createAppropriateStatusForPR({
+            context,
+            pr,
+            pendingReleaseIssueUrl
+        })
+    ));
 }
 
 /**
@@ -179,7 +185,10 @@ async function issueLabeledHandler(context) {
 
     // check if the label is post-release and the same issue has release label
     if (isPostReleaseLabel(context.payload.label) && hasReleaseLabel(context.payload.issue.labels)) {
-        await createStatusOnAllPRs({ context, pendingReleaseIssueUrl: context.payload.issue.html_url });
+        await createStatusOnAllPRs({
+            context,
+            pendingReleaseIssueUrl: context.payload.issue.html_url
+        });
     }
 }
 
@@ -193,7 +202,10 @@ async function issueCloseHandler(context) {
 
     // check if the closed issue is a release issue
     if (hasReleaseLabel(context.payload.issue.labels)) {
-        await createStatusOnAllPRs({ context, pendingReleaseIssueUrl: null });
+        await createStatusOnAllPRs({
+            context,
+            pendingReleaseIssueUrl: null
+        });
     }
 }
 

--- a/tests/plugins/release-monitor/index.js
+++ b/tests/plugins/release-monitor/index.js
@@ -106,7 +106,7 @@ describe("release-monitor", () => {
     });
 
     describe("issue labeled", () => {
-        test("in post release phase then add pending on non semver patch pr", async() => {
+        test("in post release phase then add appropriate status check to all PRs", async() => {
             mockAllOpenPrWithCommits([
                 {
                     number: 1,
@@ -187,23 +187,23 @@ describe("release-monitor", () => {
 
             const fixPrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/222")
-                .reply(200, {});
+                .reply(200, assertSuccessStatusWithPendingRelease);
 
             const updatePrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/333")
-                .reply(200, {});
+                .reply(200, assertPendingStatusWithIssueLink);
 
             const breakingPrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/444")
-                .reply(200, {});
+                .reply(200, assertPendingStatusWithIssueLink);
 
             const randomPrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/555")
-                .reply(200, {});
+                .reply(200, assertPendingStatusWithIssueLink);
 
             const docPrStatus = nock("https://api.github.com")
                 .post("/repos/test/repo-test/statuses/666")
-                .reply(200, {});
+                .reply(200, assertSuccessStatusWithPendingRelease);
 
             await bot.receive({
                 event: "issues",
@@ -236,12 +236,12 @@ describe("release-monitor", () => {
                 }
             });
 
-            expect(newPrStatus.isDone()).toBeTruthy();
-            expect(fixPrStatus.isDone()).toBeFalsy();
-            expect(docPrStatus.isDone()).toBeFalsy();
-            expect(updatePrStatus.isDone()).toBeTruthy();
-            expect(breakingPrStatus.isDone()).toBeTruthy();
-            expect(randomPrStatus.isDone()).toBeTruthy();
+            expect(newPrStatus.isDone()).toBe(true);
+            expect(fixPrStatus.isDone()).toBe(true);
+            expect(updatePrStatus.isDone()).toBe(true);
+            expect(breakingPrStatus.isDone()).toBe(true);
+            expect(randomPrStatus.isDone()).toBe(true);
+            expect(docPrStatus.isDone()).toBe(true);
         });
 
         test("with no post release label nothing happens", async() => {


### PR DESCRIPTION
This updates the `release-monitor` status check to leave the correct success status on semver-patch PRs when entering post-release mode. This allows the plugin logic to be simpler, because the appropriate action for any given PR only depends on whether the repo is in post-release mode, and it doesn't depend on what triggered the current event.