### PR TITLE
New: add issue-archiver plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The bot can perform the following tasks:
 * **Needs info** - adds a comment to issues requesting more information when a maintainer adds the `needs info` label.
 * **Release/TSC meeting issues** - creates a new issue with the `release`/`tsc meeting` label scheduled two weeks later, after another release/TSC meeting issue is closed.
 * **Release monitor** - searches the repository for an issue with the `release` and `patch release pending` labels, indicating that a patch release might soon be created from `master`. If an issue is found, adds a pending status check to all PRs that would require a semver-minor release, to prevent anyone from accidentally merging them.
+* **Issue Archiver** - Locks and adds a label to issues which have been closed for awhile
 * **PR ready to merge** (experimental) - adds a label to all PRs which are "ready to merge", defined by the following criteria:
     * At least one review is approved.
     * Build status is `success`.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.14",
-    "probot": "^4.0.0"
+    "probot": "^4.0.0",
+    "probot-scheduler": "^1.0.3"
   },
   "devDependencies": {
     "eslint": "^4.13.1",

--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,7 @@ const bot = probot({
 });
 const enabledPlugins = new Set([
     "commitMessage",
+    "issueArchiver",
     "needsInfo",
     "triage",
     "recurringIssues",

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -8,6 +8,7 @@ module.exports = {
     checkUnitTest: require("./check-unit-test"),
     commitMessage: require("./commit-message"),
     duplicateComments: require("./duplicate-comments"),
+    issueArchiver: require("./issue-archiver"),
     prReadyToMerge: require("./pr-ready-to-merge"),
     needsInfo: require("./needs-info"),
     triage: require("./triage"),

--- a/src/plugins/issue-archiver/index.js
+++ b/src/plugins/issue-archiver/index.js
@@ -75,7 +75,7 @@ async function archiveOldIssues(context) {
 }
 
 module.exports = robot => {
-    createScheduler(robot, { interval: SEARCH_INTERVAL_MS });
+    createScheduler(robot, { interval: SEARCH_INTERVAL_MS, delay: false });
 
     robot.on("schedule.repository", archiveOldIssues);
 };

--- a/src/plugins/issue-archiver/index.js
+++ b/src/plugins/issue-archiver/index.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const createScheduler = require("probot-scheduler");
+const moment = require("moment");
+
+const SEARCH_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const ARCHIVAL_AGE_DAYS = 180;
+const ARCHIVED_LABEL = "archived due to age";
+
+/**
+ * Creates a search query to look for issuesin a given repo which have been closed for at least
+ * `ARCHIVAL_AGE_DAYS` days since the current date, and have not yet been archived.
+ * @param {string} options.owner The owner of the repo where issues should be searched
+ * @param {string} options.repo The name of the repo where issues should be searched
+ * @returns {string} A search query to send to the GitHub API
+ */
+function createSearchQuery({ owner, repo }) {
+    const earliestDayWithinArchivalAge = moment().subtract({ days: ARCHIVAL_AGE_DAYS });
+
+    return [
+        "is:closed",
+        `repo:${owner}/${repo}`,
+        `-label:"${ARCHIVED_LABEL}"`,
+        `closed:<${earliestDayWithinArchivalAge.format("YYYY-MM-DD")}`
+    ].join(" ");
+}
+
+/**
+ * Locks an issue and adds the `ARCHIVED_LABEL` label.
+ * @param {probot.Context} context Probot context for the current repository
+ * @param {number} issueNum The issue number on the current repository
+ * @returns {Promise<void>} A Promise that fulfills when the issue has been archived
+ */
+async function archiveIssue(context, issueNum) {
+    await Promise.all([
+        context.github.issues.lock(context.repo({ number: issueNum })),
+        context.github.issues.addLabels(context.repo({ number: issueNum, labels: [ARCHIVED_LABEL] }))
+    ]);
+}
+
+/**
+ * Gets all archived issues on the current repository
+ * @param {probot.Context} context Probot context for the current repository
+ * @param {*} searchQuery A search query to send to the GitHub API
+ * @returns {Promise<number[]>} A list of issue numbers that match the query
+ */
+async function getAllSearchResults(context) {
+    const searchQuery = createSearchQuery(context.repo());
+
+    const issueNumbers = [];
+    let lastSearchResult;
+
+    do {
+        if (lastSearchResult) {
+            lastSearchResult = await context.github.getNextPage(lastSearchResult);
+        } else {
+            lastSearchResult = await context.github.search.issues({ q: searchQuery, per_page: 100 });
+        }
+        issueNumbers.push(...lastSearchResult.data.items.map(item => item.number));
+    } while (context.github.hasNextPage(lastSearchResult));
+
+    return issueNumbers;
+}
+
+/**
+ * Archives all closed issues and pull requests on a repository which have been closed for at least
+ * `ARCHIVAL_AGE_DAYS` days. An issue is "archived" by locking it and adding the `ARCHIVED_LABEL` label.
+ * @param {probot.Context} context Probot context for the current repository
+ * @returns {Promise<void>} A Promise that fulfills when the search is complete
+ */
+async function archiveOldIssues(context) {
+    const issueNumbersToArchive = await getAllSearchResults(context);
+
+    await Promise.all(issueNumbersToArchive.map(issueNum => archiveIssue(context, issueNum)));
+}
+
+module.exports = robot => {
+    createScheduler(robot, { interval: SEARCH_INTERVAL_MS });
+
+    robot.on("schedule.repository", archiveOldIssues);
+};

--- a/src/plugins/issue-archiver/index.js
+++ b/src/plugins/issue-archiver/index.js
@@ -62,19 +62,10 @@ async function archiveIssue(context, issueNum) {
 async function getAllSearchResults(context) {
     const searchQuery = createSearchQuery(context.repo());
 
-    const issueNumbers = [];
-    let lastSearchResult;
-
-    do {
-        if (lastSearchResult) {
-            lastSearchResult = await context.github.getNextPage(lastSearchResult);
-        } else {
-            lastSearchResult = await context.github.search.issues({ q: searchQuery, per_page: 100 });
-        }
-        issueNumbers.push(...lastSearchResult.data.items.map(item => item.number));
-    } while (context.github.hasNextPage(lastSearchResult));
-
-    return issueNumbers;
+    return context.github.paginate(
+        context.github.search.issues({ q: searchQuery, per_page: 100 }),
+        result => result.data.items.map(item => item.number)
+    );
 }
 
 /**

--- a/src/plugins/issue-archiver/index.js
+++ b/src/plugins/issue-archiver/index.js
@@ -64,7 +64,15 @@ async function getAllSearchResults(context) {
 
     return context.github.paginate(
         context.github.search.issues({ q: searchQuery, per_page: 100 }),
-        result => result.data.items.map(item => item.number)
+        result => result.data.items
+
+            /*
+             * Do not label issues which are already locked.
+             * Ideally this would be handled as part of the search filter, but this doesn't seem to
+             * work (https://api.github.com/search/issues?q=-is%3Alocked returns a 500 error).
+             */
+            .filter(issue => !issue.locked)
+            .map(issue => issue.number)
     );
 }
 

--- a/tests/plugins/issue-archiver/index.js
+++ b/tests/plugins/issue-archiver/index.js
@@ -1,0 +1,110 @@
+"use strict";
+
+const { issueArchiver } = require("../../../src/plugins/index");
+
+const nock = require("nock");
+const probot = require("probot");
+const GitHubApi = require("github");
+
+process.on("unhandledRejection", console.error); // eslint-disable-line
+
+describe("issue-archiver", () => {
+    let bot;
+
+    beforeEach(async() => {
+        bot = probot.createRobot({
+            id: "test",
+            cert: "test",
+            cache: {
+                wrap: () => Promise.resolve({ data: { token: "test" } })
+            },
+            app: () => "test"
+
+        });
+
+        const { paginate } = await bot.auth();
+
+        bot.auth = () => Object.assign(new GitHubApi(), { paginate });
+
+        nock.disableNetConnect();
+
+        nock("https://api.github.com")
+            .get("/app/installations")
+            .query(true)
+            .reply(200, [{}]);
+
+        nock("https://api.github.com")
+            .get("/installation/repositories")
+            .reply(200, {
+                total_count: 1,
+                repositories: [
+                    {
+                        owner: {
+                            login: "test"
+                        },
+                        name: "repo-test"
+                    }
+                ]
+            });
+
+        issueArchiver(bot);
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it("performs a search, and labels/archives all returned issues", async() => {
+        const search = nock("https://api.github.com")
+            .get("/search/issues")
+            .query({ q: "is:closed repo:test/repo-test -label:\"archived due to age\" closed:<2017-08-10", per_page: 100 })
+            .reply(200, {
+                total_count: 2,
+                incomplete_results: false,
+                items: [
+                    { number: 7 },
+                    { number: 5 }
+                ]
+            }, {
+            });
+
+        const firstLock = nock("https://api.github.com")
+            .put("/repos/test/repo-test/issues/7/lock")
+            .reply(200);
+
+        const firstLabels = nock("https://api.github.com")
+            .post("/repos/test/repo-test/issues/7/labels")
+            .reply(200);
+
+        const secondLock = nock("https://api.github.com")
+            .put("/repos/test/repo-test/issues/5/lock")
+            .reply(200);
+
+        const secondLabels = nock("https://api.github.com")
+            .post("/repos/test/repo-test/issues/5/labels")
+            .reply(200);
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        await bot.receive({
+            event: "schedule.repository",
+            payload: {
+                installation: {
+                    id: 1
+                },
+                repository: {
+                    name: "repo-test",
+                    owner: {
+                        login: "test"
+                    }
+                }
+            }
+        });
+
+        expect(search.isDone()).toBe(true);
+        expect(firstLock.isDone()).toBe(true);
+        expect(firstLabels.isDone()).toBe(true);
+        expect(secondLock.isDone()).toBe(true);
+        expect(secondLabels.isDone()).toBe(true);
+    });
+});

--- a/tests/plugins/issue-archiver/index.js
+++ b/tests/plugins/issue-archiver/index.js
@@ -73,8 +73,9 @@ describe("issue-archiver", () => {
                 total_count: 2,
                 incomplete_results: false,
                 items: [
-                    { number: 7 },
-                    { number: 5 }
+                    { number: 7, locked: false },
+                    { number: 6, locked: true },
+                    { number: 5, locked: false }
                 ]
             }, {
             });


### PR DESCRIPTION
(fixes https://github.com/eslint/eslint/issues/9837)

This plugin does the following:

* Every 6 hours, the bot searches for issues which were closed more than 180 days ago and do not have the `"archived due to age"` label. It then locks all of these issues and adds the `"archived due to age"` label to each of them.

TODO:

- [x] Ensure that there are no major problems with this approach
- [x] Add tests
- [x] Ensure the bot fails gracefully if the repository does not have an `"archived due to age"` label