### PR TITLE
Chore: run issue-archiver once every 24 hours

### DIFF
--- a/src/plugins/issue-archiver/index.js
+++ b/src/plugins/issue-archiver/index.js
@@ -3,7 +3,7 @@
 const createScheduler = require("probot-scheduler");
 const moment = require("moment");
 
-const SEARCH_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const SEARCH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const ARCHIVAL_AGE_DAYS = 180;
 const ARCHIVED_LABEL = "archived due to age";
 


### PR DESCRIPTION
I noticed this right after I merged #57. It doesn't make sense to run the issue archiver every 6 hours, because the search filter only has a resolution of 1 day anyway, so 3/4 of the runs would always find no new issues.