### PR TITLE
Fix: avoid error when a pull request is opened

### DIFF
--- a/src/plugins/triage/index.js
+++ b/src/plugins/triage/index.js
@@ -12,9 +12,7 @@
  * @private
  */
 async function triage(context) {
-    const payloadIssue = context.payload.issue || context.payload.pull_request;
-
-    if (payloadIssue.labels.length === 0) {
+    if (!context.payload.issue || context.payload.issue.labels.length === 0) {
 
         /*
          * Fetch the issue again to double-check that it has no labels.

--- a/src/plugins/triage/index.js
+++ b/src/plugins/triage/index.js
@@ -12,7 +12,9 @@
  * @private
  */
 async function triage(context) {
-    if (context.payload.issue.labels.length === 0) {
+    const payloadIssue = context.payload.issue || context.payload.pull_request;
+
+    if (payloadIssue.labels.length === 0) {
 
         /*
          * Fetch the issue again to double-check that it has no labels.

--- a/tests/plugins/triage/index.js
+++ b/tests/plugins/triage/index.js
@@ -223,7 +223,7 @@ describe("triage", () => {
                     installation: {
                         id: 1
                     },
-                    issue: {
+                    pull_request: {
                         labels: [],
                         number: 1
                     },

--- a/tests/plugins/triage/index.js
+++ b/tests/plugins/triage/index.js
@@ -224,7 +224,6 @@ describe("triage", () => {
                         id: 1
                     },
                     pull_request: {
-                        labels: [],
                         number: 1
                     },
                     repository: {


### PR DESCRIPTION
The bot is currently logging an error when a PR is opened, due to a bug in https://github.com/eslint/eslint-github-bot/pull/60.

```
TypeError: Cannot read property 'labels' of undefined
       at triage (/path/to/eslint-github-bot/src/plugins/triage/index.js:15:31)
       at EventEmitter.events.on (/path/to/eslint-github-bot/node_modules/probot/lib/robot.js:102:17)
       at <anonymous>
       at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```