### PR TITLE
Fix: ensure release-monitor plugin paginates pull requests (fixes #67)

### DIFF
--- a/src/plugins/release-monitor/index.js
+++ b/src/plugins/release-monitor/index.js
@@ -38,10 +38,13 @@ function pluckLatestCommitSha(allCommits) {
  * @private
  */
 function getAllOpenPRs(context) {
-    return context.github.pullRequests.getAll(
-        context.repo({
-            state: "open"
-        })
+    return context.github.paginate(
+        context.github.pullRequests.getAll(
+            context.repo({
+                state: "open"
+            })
+        ),
+        res => res.data
     );
 }
 
@@ -133,7 +136,7 @@ async function createAppropriateStatusForPR({ context, pr, pendingReleaseIssueUr
  * @private
  */
 async function createStatusOnAllPRs({ context, pendingReleaseIssueUrl }) {
-    const { data: allOpenPrs } = await getAllOpenPRs(context);
+    const allOpenPrs = await getAllOpenPRs(context);
 
     return Promise.all(allOpenPrs.map(pr =>
         createAppropriateStatusForPR({


### PR DESCRIPTION
This updates the `release-monitor` plugin to paginate the pull requests that it sees, to ensure that it works correctly when there are more than 30 open pull requests. This also updates the tests for that plugin to only return one mock pull request at a time, to simulate paginated responses.