### PR TITLE
Chore: Avoid direct call to bot.auth() in issue-archiver tests

### DIFF
--- a/tests/plugins/issue-archiver/index.js
+++ b/tests/plugins/issue-archiver/index.js
@@ -22,9 +22,12 @@ describe("issue-archiver", () => {
 
         });
 
-        const { paginate } = await bot.auth();
+        const githubApi = new GitHubApi();
 
-        bot.auth = () => Object.assign(new GitHubApi(), { paginate });
+        // TODO: Improve! (Is the probot addPaginate function exposed?)
+        githubApi.paginate = async(initialPromise, callback) => callback(await initialPromise);
+
+        bot.auth = () => Promise.resolve(githubApi);
 
         nock.disableNetConnect();
 


### PR DESCRIPTION
(N.B. Had to create the PR to trigger the Travis build. Need to test on Travis because the tests were passing locally on my machine.)