### PR TITLE
Chore: update CI to match production environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: node_js
 
 node_js:
-    - "8"
+    - "10"
 
 sudo: false
 
 branches:
     only:
     - master
+
+install:
+    - npm ci
 
 script:
     - "npm run lint"


### PR DESCRIPTION
This updates Travis to (a) run Node 10, and (b) use `npm ci` when installing packages. The production environment also runs Node 10 and uses `npm ci`, so this should reduce the liklihood of errors from things like outdated `package-lock.json` files.