### PR TITLE
Chore: Remove npm rc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock = true


### PR DESCRIPTION
We need package-lock and by default its already `true`. We dont a file to do this.