### PR TITLE
Fix: avoid reporting spurious for multiline commits referencing issues

### DIFF
--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -29,16 +29,17 @@ const EXCLUDED_REPOSITORY_NAMES = new Set([
  * @private
  */
 function checkCommitMessage(message) {
+    const commitTitle = message.split(/\r?\n/)[0];
 
     // First, check tag and summary length
-    let isValid = TAG_REGEX.test(message) && message.split(/\r?\n/)[0].length <= MESSAGE_LENGTH_LIMIT;
+    let isValid = TAG_REGEX.test(commitTitle) && commitTitle.length <= MESSAGE_LENGTH_LIMIT;
 
     // Then, if there appears to be an issue reference, test for correctness
-    if (isValid && POTENTIAL_ISSUE_REF_REGEX.test(message)) {
-        const issueSuffixMatch = CORRECT_ISSUE_REF_REGEX.exec(message);
+    if (isValid && POTENTIAL_ISSUE_REF_REGEX.test(commitTitle)) {
+        const issueSuffixMatch = CORRECT_ISSUE_REF_REGEX.exec(commitTitle);
 
         // If no suffix, or issue ref occurs before suffix, message is invalid
-        if (!issueSuffixMatch || POTENTIAL_ISSUE_REF_REGEX.test(message.slice(0, issueSuffixMatch.index))) {
+        if (!issueSuffixMatch || POTENTIAL_ISSUE_REF_REGEX.test(commitTitle.slice(0, issueSuffixMatch.index))) {
             isValid = false;
         }
     }

--- a/tests/plugins/commit-message/index.js
+++ b/tests/plugins/commit-message/index.js
@@ -232,7 +232,8 @@ describe("commit-message", () => {
                 "(fixes #1)",
                 "(refs #1)",
                 "(fixes #1, fixes #2)",
-                "(fixes #1, refs #2, fixes #3)"
+                "(fixes #1, refs #2, fixes #3)",
+                "(fixes #1234)\n\nMore info here"
             ].forEach(suffix => {
                 test(`Posts success status if the commit message references issue correctly: ${suffix}`, async() => {
                     mockSingleCommitWithMessage(
@@ -254,7 +255,7 @@ describe("commit-message", () => {
                         .post("/repos/test/repo-test/statuses/second-sha", req => req.state === "success")
                         .reply(201);
 
-                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: `New: foo ${suffix}` } });
+                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: `New: foo ${suffix.replace(/\n[\s\S]*/, "")}` } });
                     expect(nockScope.isDone()).toBeTruthy();
                 });
             });


### PR DESCRIPTION
Previously, if a PR had a single commit, and that commit's message spanned multiple lines, and the first line ended with (fixes #\<number\>), then the bot would report that the commit message didn't follow the guidelines because the issue reference wouldn't be at the "end" of the commit message. This updates the commit message checker to verify that issue references are at the end of the first line, rather than at the end of the entire commit message.