### PR TITLE
Fix: typo in webhook name for WIP plugin (fixes #80)

### DIFF
--- a/src/plugins/wip/index.js
+++ b/src/plugins/wip/index.js
@@ -141,7 +141,7 @@ function prHasWipTitle(pr) {
 }
 
 /**
- * Handler for PR events (opened, reopened, synchronized, edited, labeled,
+ * Handler for PR events (opened, reopened, synchronize, edited, labeled,
  * unlabeled).
  * @param {Object} context - probot context object
  * @returns {Promise} promise
@@ -174,7 +174,7 @@ module.exports = robot => {
             "pull_request.edited",
             "pull_request.labeled",
             "pull_request.unlabeled",
-            "pull_request.synchronized"
+            "pull_request.synchronize"
         ],
         prChangedHandler
     );

--- a/tests/plugins/wip/index.js
+++ b/tests/plugins/wip/index.js
@@ -81,7 +81,7 @@ describe("wip", () => {
         nock.cleanAll();
     });
 
-    ["opened", "reopened", "edited", "labeled", "unlabeled", "synchronized"].forEach(action => {
+    ["opened", "reopened", "edited", "labeled", "unlabeled", "synchronize"].forEach(action => {
         describe(`pull request ${action}`, () => {
             test("create pending status if PR title starts with 'WIP:'", async() => {
                 mockGetAllCommitsForPR({


### PR DESCRIPTION
This fixes a typo where the WIP plugin is listening for `synchronized` events rather than `synchronize` events, which prevented the fix for #80 from working correctly. (For some reason, the webhook from GitHub is called [`synchronize`](https://developer.github.com/v3/activity/events/types/#events-api-payload-28) even though other webhook names are in past tense.)