### PR TITLE
Fix: skip other checks if commit message starts with 'Revert "' (fixes #89)

### DIFF
--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -8,7 +8,7 @@
 
 const { getCommitMessageForPR } = require("../utils");
 
-const TAG_REGEX = /^((?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade):|Revert )/;
+const TAG_REGEX = /^((?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade):)/;
 
 const POTENTIAL_ISSUE_REF_REGEX = /#\d+/;
 
@@ -30,6 +30,10 @@ const EXCLUDED_REPOSITORY_NAMES = new Set([
  */
 function checkCommitMessage(message) {
     const commitTitle = message.split(/\r?\n/)[0];
+
+    if (message.startsWith("Revert \"")) {
+        return true;
+    }
 
     // First, check tag and summary length
     let isValid = TAG_REGEX.test(commitTitle) && commitTitle.length <= MESSAGE_LENGTH_LIMIT;

--- a/tests/plugins/commit-message/index.js
+++ b/tests/plugins/commit-message/index.js
@@ -271,6 +271,23 @@ describe("commit-message", () => {
                     }
                 });
             });
+
+            // Tests for commit messages starting with 'Revert "'
+            [
+                "Revert \"New: do something (#123)\"",
+                "Revert \"Very long commit message with lots and lots of characters (more than 72!)\"",
+                "Revert \"blah\"\n\nbaz"
+            ].forEach(message => {
+                test("Posts a success status", async() => {
+                    const nockScope = nock("https://api.github.com")
+                        .post("/repos/test/repo-test/statuses/first-sha", req => req.state === "success")
+                        .reply(201);
+
+                    mockSingleCommitWithMessage(message);
+                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: message.replace(/\n[\s\S]*/, "") } });
+                    expect(nockScope.isDone()).toBe(true);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Fixes #89