### PR TITLE
New: auto-closer plugin (fixes #92)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,14 +2453,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2475,20 +2473,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2605,8 +2600,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2618,7 +2612,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2633,7 +2626,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2745,8 +2737,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2758,7 +2749,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2880,7 +2870,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,12 +2453,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2473,17 +2475,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2600,7 +2605,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2612,6 +2618,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2626,6 +2633,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2737,7 +2745,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2749,6 +2758,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2870,6 +2880,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ const bot = probot.createProbot({
     id: process.env.APP_ID
 });
 const enabledPlugins = new Set([
+    "autoCloser",
     "commitMessage",
     "issueArchiver",
     "needsInfo",

--- a/src/plugins/auto-closer/index.js
+++ b/src/plugins/auto-closer/index.js
@@ -20,7 +20,7 @@ const AUTO_CLOSE_LABEL = "auto closed";
  */
 async function hasAutoCloseLabel(context) {
     const allLabels = await context.github.paginate(
-        context.github.issues.getLabels(context.repo()),
+        context.github.issues.listLabelsForRepo(context.repo()),
         res => res.data
     );
 
@@ -119,7 +119,7 @@ Thanks for contributing to ESLint and we appreciate your understanding.
  */
 async function closeIssue(context, issueNum, commentText) {
     await Promise.all([
-        context.github.issues.edit(context.repo({ number: issueNum, state: "closed" })),
+        context.github.issues.update(context.repo({ number: issueNum, state: "closed" })),
         context.github.issues.addLabels(context.repo({ number: issueNum, labels: [AUTO_CLOSE_LABEL] })),
         context.github.issues.createComment(context.repo({ number: issueNum, body: commentText }))
     ]);

--- a/src/plugins/auto-closer/index.js
+++ b/src/plugins/auto-closer/index.js
@@ -1,0 +1,172 @@
+/**
+ * Auto-closes issues in GitHub repos.
+ * @author Nicholas C. Zakas
+ */
+"use strict";
+
+const createScheduler = require("probot-scheduler");
+const moment = require("moment");
+
+const SEARCH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const ACCEPTED_AUTO_CLOSE_DAYS = 90;
+const ACTIVITY_AUTO_CLOSE_DAYS = 30;
+const AUTO_CLOSE_LABEL = "auto closed";
+
+
+/**
+ * Checks whether the current repository has a `AUTO_CLOSE_LABEL` label
+ * @param {probot.Context} context Probot context for the current repository
+ * @returns {Promise<boolean>} `true` if the repository has a label with appropriate name
+ */
+async function hasAutoCloseLabel(context) {
+    const allLabels = await context.github.paginate(
+        context.github.issues.getLabels(context.repo()),
+        res => res.data
+    );
+
+    return allLabels.some(label => label.name === AUTO_CLOSE_LABEL);
+}
+
+
+/**
+ * Creates a search query to look for issues in a given repo that have been
+ * labeled "accepted", don't have an assignee/project/milestone, have been opened
+ * for 90 days and have been inactive for 30 days.
+ * @param {string} options.owner The owner of the repo where issues should be searched
+ * @param {string} options.repo The name of the repo where issues should be searched
+ * @returns {string} A search query to send to the GitHub API
+ */
+function createAutoCloseAcceptedSearchQuery({ owner, repo }) {
+    const creationCutoffDate = moment().subtract({ days: ACCEPTED_AUTO_CLOSE_DAYS });
+    const activityCutoffDate = moment().subtract({ days: ACTIVITY_AUTO_CLOSE_DAYS });
+
+    return [
+        "is:open",
+        `repo:${owner}/${repo}`,
+        "no:assignee no:milestone no:project label:accepted",
+        `created:<${creationCutoffDate.format("YYYY-MM-DD")}`,
+        `updated:<${activityCutoffDate.format("YYYY-MM-DD")}`
+    ].join(" ");
+}
+
+/**
+ * Creates a search query to look for issues in a given repo that have not been
+ * labeled "accepted", don't have an assignee/project/milestone, have been
+ * inactive for 30 days.
+ * @param {string} options.owner The owner of the repo where issues should be searched
+ * @param {string} options.repo The name of the repo where issues should be searched
+ * @returns {string} A search query to send to the GitHub API
+ */
+function createAutoCloseUnacceptedSearchQuery({ owner, repo }) {
+    const activityCutoffDate = moment().subtract({ days: ACTIVITY_AUTO_CLOSE_DAYS });
+
+    return [
+        "is:open",
+        `repo:${owner}/${repo}`,
+        "no:assignee no:milestone no:project -label:accepted",
+        `updated:<${activityCutoffDate.format("YYYY-MM-DD")}`
+    ].join(" ");
+}
+
+/**
+ * Creates the bot comment to leave on auto-closed accepted issues.
+ * @returns {string} comment message
+ * @private
+ */
+function createAcceptedAutoCloseMessage() {
+    return `
+Unfortunately, it looks like there wasn't enough interest from the team
+or community to implement this change. While we wish we'd be able to
+accommodate everyone's requests, we do need to prioritize. We've found
+that accepted issues failing to be implemented after 90 days tend to
+never be implemented, and as such, we [close those issues](https://eslint.org/docs/maintainer-guide/issues#when-to-close-an-issue).
+This doesn't mean the idea isn't interesting or useful, just that it's
+not something the team can commit to.
+
+Thanks for contributing to ESLint and we appreciate your understanding.
+
+[//]: # (auto-close)
+`;
+}
+
+/**
+ * Creates the bot comment to leave on auto-closed unaccepted issues.
+ * @returns {string} comment message
+ * @private
+ */
+function createUnacceptedAutoCloseMessage() {
+    return `
+Unfortunately, it looks like there wasn't enough interest from the team
+or community to implement this change. While we wish we'd be able to
+accommodate everyone's requests, we do need to prioritize. We've found
+that issues failing to reach accepted status after 21 days tend to
+never be accepted, and as such, we [close those issues](https://eslint.org/docs/maintainer-guide/issues#when-to-close-an-issue).
+This doesn't mean the idea isn't interesting or useful, just that it's
+not something the team can commit to.
+
+Thanks for contributing to ESLint and we appreciate your understanding.
+
+[//]: # (auto-close)
+`;
+}
+
+/**
+ * Closes an issue and adds the auto-close label.
+ * @param {probot.Context} context Probot context for the current repository
+ * @param {number} issueNum The issue number on the current repository
+ * @param {string} commentText The text of the comment to post on the issue.
+ * @returns {Promise<void>} A Promise that fulfills when the issue has been archived
+ */
+async function closeIssue(context, issueNum, commentText) {
+    await Promise.all([
+        context.github.issues.edit(context.repo({ number: issueNum, state: "closed" })),
+        context.github.issues.addLabels(context.repo({ number: issueNum, labels: [AUTO_CLOSE_LABEL] })),
+        context.github.issues.createComment(context.repo({ number: issueNum, body: commentText }))
+    ]);
+}
+
+/**
+ * Gets all issues on the current repository that match a search query
+ * @param {probot.Context} context Probot context for the current repository
+ * @param {string} searchQuery A search query to send to the GitHub API
+ * @returns {Promise<issue>} A list of issues that match the query
+ */
+async function queryIssues(context, searchQuery) {
+    return context.github.paginate(
+        context.github.search.issues({ q: searchQuery, per_page: 100 }),
+        result => result.data.items
+    );
+}
+
+/**
+ * Autocloses issues on a repository based on labels and activity level.
+ * @param {probot.Context} context Probot context for the current repository
+ * @returns {Promise<void>} A Promise that fulfills when the search is complete
+ */
+async function closeInactiveIssues(context) {
+
+    // repos that want auto close must first create a label
+    if (!await hasAutoCloseLabel(context)) {
+        return;
+    }
+
+    const [acceptedIssues, unacceptedIssues] = await Promise.all([
+        queryIssues(context, createAutoCloseAcceptedSearchQuery(context)),
+        queryIssues(context, createAutoCloseUnacceptedSearchQuery(context))
+    ]);
+
+    await Promise.all(acceptedIssues.map(
+        issue => closeIssue(context, issue.number, createAcceptedAutoCloseMessage())
+    ));
+
+    await Promise.all(unacceptedIssues.map(
+        issue => closeIssue(context, issue.number, createUnacceptedAutoCloseMessage())
+    ));
+}
+
+
+module.exports = robot => {
+    createScheduler(robot, { interval: SEARCH_INTERVAL_MS, delay: false });
+
+    robot.on("schedule.repository", closeInactiveIssues);
+};

--- a/src/plugins/auto-closer/index.js
+++ b/src/plugins/auto-closer/index.js
@@ -131,7 +131,7 @@ async function closeIssue(context, issueNum, commentText) {
  * @param {string} searchQuery A search query to send to the GitHub API
  * @returns {Promise<issue>} A list of issues that match the query
  */
-async function queryIssues(context, searchQuery) {
+function queryIssues(context, searchQuery) {
     return context.github.paginate(
         context.github.search.issues({ q: searchQuery, per_page: 100 }),
         result => result.data.items

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,7 +1,15 @@
+/**
+ * @fileoverview Exports all plugins for easy inclusion elsewhere.
+ * @author Gyandeep Singh
+ */
+
 "use strict";
 
 /**
  * All the exposed plugins
+ *
+ * Note that exported plugins are not automatically loaded into
+ * the bot. You need to also update app.js.
  */
 
 module.exports = {

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -5,6 +5,7 @@
  */
 
 module.exports = {
+    autoCloser: require("./auto-closer"),
     checkUnitTest: require("./check-unit-test"),
     commitMessage: require("./commit-message"),
     duplicateComments: require("./duplicate-comments"),

--- a/tests/plugins/auto-closer/index.js
+++ b/tests/plugins/auto-closer/index.js
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Tests for the auto-closer plugin.
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const { autoCloser } = require("../../../src/plugins/index");
+
+const nock = require("nock");
+const probot = require("probot");
+const GitHubApi = require("@octokit/rest");
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+let githubNock = nock("https://api.github.com");
+
+/**
+ * Creates a Nock mock for applying issue labels.
+ * @param {number} issueNum The issue number that should be labeled.
+ * @returns {Nock} The Nock instance.
+ */
+function checkNockLabelRequest(issueNum) {
+    return githubNock
+        .post(`/repos/test/repo-test/issues/${issueNum}/labels`,
+            ["auto closed"]
+        )
+        .reply(200);
+}
+
+/**
+ * Creates a Nock mock for closing issues.
+ * @param {number} issueNum The issue number that should be closed.
+ * @returns {Nock} The Nock instance.
+ */
+function checkNockClosedRequest(issueNum) {
+    return githubNock
+        .patch(`/repos/test/repo-test/issues/${issueNum}`, {
+            state: "closed"
+        })
+        .reply(200);
+}
+
+/**
+ * Creates a Nock mock for commenting on issues.
+ * @param {number} issueNum The issue number that should be commented on.
+ * @returns {Nock} The Nock instance.
+ */
+function checkNockCommentRequest(issueNum) {
+    return githubNock
+        .post(`/repos/test/repo-test/issues/${issueNum}/comments`, {
+            body: /days/
+        })
+        .reply(200);
+}
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("auto-closer", () => {
+    let bot;
+
+    beforeEach(async() => {
+        githubNock = nock("https://api.github.com");
+        bot = new probot.Application({
+            id: "test",
+            cert: "test",
+            cache: {
+                wrap: () => Promise.resolve({ data: { token: "test" } })
+            },
+            app: () => "test"
+        });
+
+        const { paginate } = await bot.auth();
+
+        bot.auth = () => Object.assign(new GitHubApi(), { paginate });
+
+        nock.disableNetConnect();
+
+        githubNock
+            .get("/app/installations")
+            .query(true)
+            .reply(200, [{
+                id: 1,
+                account: {
+                    login: "test"
+                }
+            }]);
+
+        githubNock
+            .get("/installation/repositories")
+            .query(true)
+            .reply(200, {
+                total_count: 1,
+                repositories: [
+                    {
+                        owner: {
+                            login: "test"
+                        },
+                        name: "repo-test"
+                    }
+                ]
+            });
+
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    it("performs a search, and closes all returned issues", async() => {
+        const labelSearch = githubNock
+            .get("/repos/test/repo-test/labels")
+            .reply(200, [
+                {
+                    name: "auto closed"
+                },
+                {
+                    name: "accepted"
+                }
+            ]);
+
+        const acceptedIssueSearch = githubNock
+            .get("/search/issues")
+            .query(value => value.q.includes(" label:accepted"))
+            .reply(200, {
+                total_count: 2,
+                incomplete_results: false,
+                items: [
+                    { number: 1 },
+                    { number: 2 }
+                ]
+            }, {
+            });
+
+        const unacceptedIssueSearch = nock("https://api.github.com")
+            .get("/search/issues")
+            .query(value => value.q.includes(" -label:accepted"))
+            .reply(200, {
+                total_count: 2,
+                incomplete_results: false,
+                items: [
+                    { number: 3 },
+                    { number: 4 }
+                ]
+            }, {
+            });
+
+        // check that labels are updated
+        const issueNumbers = [1, 2, 3, 4];
+        const labelRequests = issueNumbers.map(issueNum => checkNockLabelRequest(issueNum));
+        const closedRequests = issueNumbers.map(issueNum => checkNockClosedRequest(issueNum));
+        const commentRequests = issueNumbers.map(issueNum => checkNockCommentRequest(issueNum));
+
+        autoCloser(bot);
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        expect(acceptedIssueSearch.isDone()).toBe(true);
+        expect(unacceptedIssueSearch.isDone()).toBe(true);
+        expect(labelSearch.isDone()).toBe(true);
+
+        for (const labelRequest of labelRequests) {
+            expect(labelRequest.isDone()).toBe(true);
+        }
+
+        for (const closedRequest of closedRequests) {
+            expect(closedRequest.isDone()).toBe(true);
+        }
+
+        for (const commentRequest of commentRequests) {
+            expect(commentRequest.isDone()).toBe(true);
+        }
+    });
+
+    it("does not close any issues if the appropriate label does not exist", async() => {
+        const labelSearch = githubNock
+            .get("/repos/test/repo-test/labels")
+            .reply(200, [
+                {
+                    name: "foo"
+                },
+                {
+                    name: "bar"
+                }
+            ]);
+
+        autoCloser(bot);
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        expect(labelSearch.isDone()).toBe(true);
+    });
+});


### PR DESCRIPTION
This is the long-await auto-closer plugin for the bot. I initially wanted to look for issues who had the "accepted" label added 90 days ago, but it's hard to do that with the GitHub API, so I used activity level to approximate things.

This plugin auto closes:

* **accepted issues** if the issue has no assignee/project/milestone, was opened > 90 days ago and was last updated > 30 days ago.
* **unaccepted issues** if the issue has no assignee/project/milestone and was last updated > 30 days ago. (Our guidelines say unaccepted issues can be closed within 21 days, but it was easier to use 30 days for both queries. I don't think this makes much of a difference.)

This plugin does not have the "nag" feature originally referenced in #92 (to post a comment to remind assignees to work on the issue) because I wanted to keep this plugin strictly about closing. We can add a separate nag plugin if we want.