### PR TITLE
Fix: Autocloser bot plugin error (refs #98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The bot can perform the following tasks:
 * **Needs info** - adds a comment to issues requesting more information when a maintainer adds the `needs info` label.
 * **Release/TSC meeting issues** - creates a new issue with the `release`/`tsc meeting` label scheduled two weeks later, after another release/TSC meeting issue is closed.
 * **Release monitor** - searches the repository for an issue with the `release` and `patch release pending` labels, indicating that a patch release might soon be created from `master`. If an issue is found, adds a pending status check to all PRs that would require a semver-minor release, to prevent anyone from accidentally merging them.
-* **Issue Archiver** - Locks and adds a label to issues which have been closed for awhile
+* **Issue Archiver** - Locks and adds a label to issues which have been closed for a while
+* **Issue Closer** - Closes and adds a label to issues which have been inactive for a while
 * **WIP Tracking** - adds pending status check for PRs with WIP in the title or with "do not merge" label, and marks the status check as successful once the WIP indicators are removed.
 * **PR ready to merge** (experimental) - adds a label to all PRs which are "ready to merge", defined by the following criteria:
     * At least one review is approved.

--- a/src/plugins/auto-closer/index.js
+++ b/src/plugins/auto-closer/index.js
@@ -151,8 +151,8 @@ async function closeInactiveIssues(context) {
     }
 
     const [acceptedIssues, unacceptedIssues] = await Promise.all([
-        queryIssues(context, createAutoCloseAcceptedSearchQuery(context)),
-        queryIssues(context, createAutoCloseUnacceptedSearchQuery(context))
+        queryIssues(context, createAutoCloseAcceptedSearchQuery(context.repo())),
+        queryIssues(context, createAutoCloseUnacceptedSearchQuery(context.repo()))
     ]);
 
     await Promise.all(acceptedIssues.map(

--- a/tests/plugins/auto-closer/index.js
+++ b/tests/plugins/auto-closer/index.js
@@ -134,7 +134,12 @@ describe("auto-closer", () => {
 
         githubNock
             .get("/search/issues")
-            .query(value => value.q.includes(" label:accepted"))
+            .query(value => {
+
+                // GitHub API requires queries to be <=256 chars
+                expect(value.q.length).toBeLessThanOrEqual(256);
+                return value.q.includes(" label:accepted");
+            })
             .reply(200, {
                 total_count: 2,
                 incomplete_results: false,
@@ -147,7 +152,12 @@ describe("auto-closer", () => {
 
         nock("https://api.github.com")
             .get("/search/issues")
-            .query(value => value.q.includes(" -label:accepted"))
+            .query(value => {
+
+                // GitHub API requires queries to be <=256 chars
+                expect(value.q.length).toBeLessThanOrEqual(256);
+                return value.q.includes(" -label:accepted");
+            })
             .reply(200, {
                 total_count: 2,
                 incomplete_results: false,


### PR DESCRIPTION
This fixes the "search query is too long" error described in #98. I fixed the code and added assertions to ensure that long search queries are caught.