### PR TITLE
Update: Don't auto close blocked issues (fixes #104)

### DIFF
--- a/src/plugins/auto-closer/index.js
+++ b/src/plugins/auto-closer/index.js
@@ -43,7 +43,7 @@ function createAutoCloseAcceptedSearchQuery({ owner, repo }) {
     return [
         "is:open is:issue",
         `repo:${owner}/${repo}`,
-        "no:assignee no:milestone no:project label:accepted",
+        "no:assignee no:milestone no:project label:accepted -label:blocked",
         `created:<${creationCutoffDate.format("YYYY-MM-DD")}`,
         `updated:<${activityCutoffDate.format("YYYY-MM-DD")}`
     ].join(" ");
@@ -63,7 +63,8 @@ function createAutoCloseUnacceptedSearchQuery({ owner, repo }) {
     return [
         "is:open is:issue",
         `repo:${owner}/${repo}`,
-        "no:assignee no:milestone no:project -label:accepted -label:question",
+        "no:assignee no:milestone no:project",
+        "-label:accepted -label:question -label:blocked",
         `updated:<${activityCutoffDate.format("YYYY-MM-DD")}`
     ].join(" ");
 }
@@ -82,7 +83,8 @@ function createAutoCloseQuestionSearchQuery({ owner, repo }) {
     return [
         "is:open is:issue",
         `repo:${owner}/${repo}`,
-        "no:assignee no:milestone no:project -label:accepted label:question",
+        "no:assignee no:milestone no:project",
+        "-label:accepted label:question -label:blocked",
         `updated:<${activityCutoffDate.format("YYYY-MM-DD")}`
     ].join(" ");
 }

--- a/tests/plugins/auto-closer/index.js
+++ b/tests/plugins/auto-closer/index.js
@@ -141,7 +141,9 @@ describe("auto-closer", () => {
 
                 // GitHub API requires queries to be <=256 chars
                 expect(value.q.length).toBeLessThanOrEqual(256);
-                return value.q.includes(" label:accepted") && value.q.includes("is:issue");
+                return value.q.includes(" label:accepted") &&
+                    value.q.includes("is:issue") &&
+                    value.q.includes("-label:blocked");
             })
             .reply(200, {
                 total_count: 2,
@@ -160,7 +162,10 @@ describe("auto-closer", () => {
 
                 // GitHub API requires queries to be <=256 chars
                 expect(value.q.length).toBeLessThanOrEqual(256);
-                return value.q.includes(" -label:accepted") && value.q.includes(" -label:question") && value.q.includes("is:issue");
+                return value.q.includes(" -label:accepted") &&
+                    value.q.includes(" -label:question") &&
+                    value.q.includes("is:issue") &&
+                    value.q.includes("-label:blocked");
             })
             .reply(200, {
                 total_count: 2,
@@ -179,7 +184,10 @@ describe("auto-closer", () => {
 
                 // GitHub API requires queries to be <=256 chars
                 expect(value.q.length).toBeLessThanOrEqual(256);
-                return value.q.includes(" -label:accepted") && value.q.includes("label:question") && value.q.includes("is:issue");
+                return value.q.includes(" -label:accepted") &&
+                    value.q.includes("label:question") &&
+                    value.q.includes("is:issue") &&
+                    value.q.includes("-label:blocked");
             })
             .reply(200, {
                 total_count: 2,


### PR DESCRIPTION
This update simply removes all blocked issues from consideration for auto-closing. 