### PR TITLE
Fix: commit-message failed on RFC refs

### DIFF
--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -12,7 +12,7 @@ const TAG_REGEX = /^((?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade):)/;
 
 const POTENTIAL_ISSUE_REF_REGEX = /#\d+/;
 
-const VALID_ISSUE_REF = "(?:(?:fixes|refs) #\\d+)";
+const VALID_ISSUE_REF = "(?:(?:fixes|refs) (?:[^/]+[/][^/]+)?#\\d+)";
 const CORRECT_ISSUE_REF_REGEX = new RegExp(` \\(${VALID_ISSUE_REF}(?:, ${VALID_ISSUE_REF})*\\)$`);
 
 const MESSAGE_LENGTH_LIMIT = 72;

--- a/tests/plugins/commit-message/index.js
+++ b/tests/plugins/commit-message/index.js
@@ -200,7 +200,11 @@ describe("commit-message", () => {
                 "(fixes #1, #2)",
 
                 // Unexpected issue number with valid suffix should fail
-                "#1 (fixes #1)"
+                "#1 (fixes #1)",
+
+                // Invalid repo names
+                "(fixes eslint#1)",
+                "(refs eslint/nested/group#1)"
             ].forEach(suffix => {
                 test(`Posts failure status if the commit message references issue improperly: ${suffix}`, async() => {
                     mockSingleCommitWithMessage(
@@ -233,7 +237,9 @@ describe("commit-message", () => {
                 "(refs #1)",
                 "(fixes #1, fixes #2)",
                 "(fixes #1, refs #2, fixes #3)",
-                "(fixes #1234)\n\nMore info here"
+                "(fixes #1234)\n\nMore info here",
+                "(fixes eslint/rfcs#1)",
+                "(refs eslint/rfcs#1)"
             ].forEach(suffix => {
                 test(`Posts success status if the commit message references issue correctly: ${suffix}`, async() => {
                     mockSingleCommitWithMessage(


### PR DESCRIPTION
This PR fixes `commit-message` plugin to succeed with `(refs eslint/rfcs#22)`-like references.