### PR TITLE
Update: only require one volunteer when creating release issue

### DIFF
--- a/src/plugins/recurring-issues/index.js
+++ b/src/plugins/recurring-issues/index.js
@@ -17,8 +17,7 @@ async function getReleaseIssueBody(releaseDate) {
 
 The scheduled release on ${releaseDate.format("dddd, MMMM Do, YYYY")} is assigned to:
 
-* (needs volunteers)
-* (needs volunteers)
+* (needs volunteer)
 
 Please use this issue to document how the release went, any problems during the release, and anything the team might want to know about the release process. This issue should be closed after all patch releases have been completed (or there was no patch release needed).
 


### PR DESCRIPTION
Updating our release issue template to reflect [our decision to allow one person releases](https://github.com/eslint/tsc-meetings/blob/master/notes/2020/2020-02-27.md#release-cadence). This doesn't mean multiple can't run a release, but I think it makes sense to have the second person be additive.