### PR TITLE
Update: require space after "Tag:" in commit message

### DIFF
--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -8,7 +8,7 @@
 
 const { getCommitMessageForPR } = require("../utils");
 
-const TAG_REGEX = /^((?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade):)/;
+const TAG_REGEX = /^(?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade): /;
 
 const POTENTIAL_ISSUE_REF_REGEX = /#\d+/;
 


### PR DESCRIPTION
This PR updates `commit-message` to require a space after tag, per the [commit message format](https://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes):

* `New:foo` is invalid
* `New: foo` is valid