### PR TITLE
Fix: change gitter link to discord link in auto-closer

### DIFF
--- a/src/plugins/auto-closer/index.js
+++ b/src/plugins/auto-closer/index.js
@@ -140,8 +140,9 @@ function createQuestionAutoCloseMessage() {
     return `
 It looks like the conversation is stalled here. As this is a question rather
 than an action item, I'm closing the issue. If you still need help, please send
-a message to our [mailing list](https://groups.google.com/group/eslint) or 
-[chatroom](https://gitter.im/eslint/eslint). Thanks!
+a message to our [mailing list](https://groups.google.com/group/eslint) or
+[chatroom](https://eslint.org/chat). Thanks!
+
 [//]: # (auto-close)
 `;
 }


### PR DESCRIPTION
Fixes `auto-closer`'s comment for closed questions:

* The chatroom link will be now: `https://eslint.org/chat`
* Also adds a blank line before the hash, which should make it being hidden (as a link reference). It's currently visible, see [eslint/eslint#13418 (comment)](https://github.com/eslint/eslint/issues/13418#issuecomment-660562995)