### PR TITLE
New: comment with the report for commit message (fixes #127)

### DIFF
--- a/src/plugins/commit-message/createMessage.js
+++ b/src/plugins/commit-message/createMessage.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Create the message that needs to be commented in the Pull Request.
+ * @author Aniketh Saha
+ */
+
+"use strict";
+
+const MESSAGE_LENGTH_LIMIT = 72;
+
+const ERROR_MESSAGES = {
+    SPACE_AFTER_TAG_COLON: "- There should be a space following the initial tag and colon, for example 'New: Message'.",
+    NON_UPPERCASE_FIRST_LETTER_TAG: "- The first letter of the tag should be in uppercase",
+    NON_MATCHED_TAG: `- The commit message tag must be one of the following:
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implements a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+`,
+    LONG_MESSAGE: `- The length of the commit message must be less than or equal to ${MESSAGE_LENGTH_LIMIT}`,
+    WRONG_REF: `- The issue reference must be formatted as follows:
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+`
+};
+
+/**
+ * Create a comment message body with the error details
+ * @param {Array<string>} errors - list of the error codes
+ * @param {boolean} isTitle - whether it is for title or the commit message
+ * @param {string} username - username of the PR author
+ * @returns {string} the message to comment
+ * @private
+ */
+module.exports = function commentMessage(errors = [], isTitle = false, username) {
+    const errorMessages = [];
+
+    errors.forEach(err => {
+        if (ERROR_MESSAGES[err]) {
+            errorMessages.push(ERROR_MESSAGES[err]);
+        }
+    });
+
+    return `Hi @${username}!, thanks for the Pull Request
+
+The ${isTitle ? "pull request title" : "first commit message"} isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+
+${errorMessages.join("\n")}
+
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+`;
+
+};

--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -33,12 +33,12 @@ const EXCLUDED_REPOSITORY_NAMES = new Set([
  * @returns {boolean} `true` if the commit message is valid
  * @private
  */
-function checkCommitMessage(message) {
+function getCommitMessageErrors(message) {
     const commitTitle = message.split(/\r?\n/)[0];
     const errors = [];
 
     if (message.startsWith("Revert \"")) {
-        return { errors };
+        return errors;
     }
 
     // First, check tag and summary length
@@ -69,7 +69,7 @@ function checkCommitMessage(message) {
         }
     }
 
-    return { errors };
+    return errors;
 }
 
 /**
@@ -94,7 +94,7 @@ async function processCommitMessage(context) {
 
     const allCommits = await github.pullRequests.listCommits(context.issue());
     const messageToCheck = getCommitMessageForPR(allCommits.data, payload.pull_request);
-    const { errors } = checkCommitMessage(messageToCheck);
+    const errors = getCommitMessageErrors(messageToCheck);
     let description;
     let state;
 

--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -7,10 +7,13 @@
 "use strict";
 
 const { getCommitMessageForPR } = require("../utils");
+const commentMessage = require("./createMessage");
 
 const TAG_REGEX = /^(?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade): /;
 
 const TAG_SPACE_REGEX = /^(?:[A-Z][a-z]+: )/;
+
+const UPPERCASE_TAG_REGEX = /^[A-Z]/;
 
 const POTENTIAL_ISSUE_REF_REGEX = /#\d+/;
 
@@ -24,39 +27,6 @@ const EXCLUDED_REPOSITORY_NAMES = new Set([
     "tsc-meetings"
 ]);
 
-const ERR_CODES_MAPS = {
-    SPACE_AFTER_TAG_COLON: "- There should be only one whitespace after tag followed by colon i.e `<tag>: `.",
-    NON_MATCHED_TAG: `- The commit message tag doesnt match the tags mentioned below
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
-
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
-`,
-    LONG_MESSAGE: `- The lenght of the commit message should be less than or equal to ${MESSAGE_LENGTH_LIMIT}`,
-    WRONG_REF: `- The issue reference is not as per the format.
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-`
-};
-
-
 /**
  * Apply different checks on the commit message
  * @param {string} message - commit message
@@ -65,73 +35,41 @@ const ERR_CODES_MAPS = {
  */
 function checkCommitMessage(message) {
     const commitTitle = message.split(/\r?\n/)[0];
-    const errCode = [];
+    const errors = [];
 
     if (message.startsWith("Revert \"")) {
-        return [true, []];
+        return { errors };
     }
-
-    let isValid = true;
 
     // First, check tag and summary length
     if (!TAG_REGEX.test(commitTitle)) {
-        isValid = false;
-        errCode.push("NON_MATCHED_TAG");
+        errors.push("NON_MATCHED_TAG");
     }
 
     // Check if there is any whitespace after the <Tag>:
     if (!TAG_SPACE_REGEX.test(commitTitle)) {
-        isValid = false;
-        errCode.push("SPACE_AFTER_TAG_COLON");
+        errors.push("SPACE_AFTER_TAG_COLON");
+    }
+
+    if (!UPPERCASE_TAG_REGEX.test(commitTitle)) {
+        errors.push("NON_UPPERCASE_FIRST_LETTER_TAG");
     }
 
     if (!(commitTitle.length <= MESSAGE_LENGTH_LIMIT)) {
-        isValid = false;
-        errCode.push("LONG_MESSAGE");
+        errors.push("LONG_MESSAGE");
     }
 
     // Then, if there appears to be an issue reference, test for correctness
-    if (isValid && POTENTIAL_ISSUE_REF_REGEX.test(commitTitle)) {
+    if (errors.length === 0 && POTENTIAL_ISSUE_REF_REGEX.test(commitTitle)) {
         const issueSuffixMatch = CORRECT_ISSUE_REF_REGEX.exec(commitTitle);
 
         // If no suffix, or issue ref occurs before suffix, message is invalid
         if (!issueSuffixMatch || POTENTIAL_ISSUE_REF_REGEX.test(commitTitle.slice(0, issueSuffixMatch.index))) {
-            isValid = false;
-            errCode.push("WRONG_REF");
+            errors.push("WRONG_REF");
         }
     }
 
-    return [isValid, errCode];
-}
-
-/**
- * Create a comment message body with the error details
- * @param {Array<string>} errCodes - list of the error codes
- * @param {boolean} isTitle - whether it is for title or the commit message
- * @param {string} username - username of the PR author
- * @returns {string} the message to comment
- * @private
- */
-function commentMessage(errCodes = [], isTitle = false, username) {
-    const errorMessages = [];
-
-    errCodes.forEach(err => {
-        if (ERR_CODES_MAPS[err]) {
-            errorMessages.push(ERR_CODES_MAPS[err]);
-        }
-    });
-
-    return `Hi @${username}!, thanks for the Pull Request
-
-The ${isTitle ? "PR title" : "first commit message"} format is not according to our format.
-
-#### Here are the following errors
-
-${errorMessages.join("\n")}
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
-`;
-
+    return { errors };
 }
 
 /**
@@ -156,11 +94,11 @@ async function processCommitMessage(context) {
 
     const allCommits = await github.pullRequests.listCommits(context.issue());
     const messageToCheck = getCommitMessageForPR(allCommits.data, payload.pull_request);
-    const [isValid, errCodes] = checkCommitMessage(messageToCheck);
+    const { errors } = checkCommitMessage(messageToCheck);
     let description;
     let state;
 
-    if (isValid) {
+    if (errors.length === 0) {
         state = "success";
         description = allCommits.data.length === 1
             ? "Commit message follows guidelines"
@@ -185,7 +123,7 @@ async function processCommitMessage(context) {
 
     if (state === "failure") {
         await github.issues.createComment(context.issue({
-            body: commentMessage(errCodes, allCommits.data.length !== 1, payload.pull_request.user.login)
+            body: commentMessage(errors, allCommits.data.length !== 1, payload.pull_request.user.login)
         }));
     }
 

--- a/tests/plugins/commit-message/__snapshots__/index.js.snap
+++ b/tests/plugins/commit-message/__snapshots__/index.js.snap
@@ -3,344 +3,323 @@
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -353,18 +332,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -377,18 +354,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -401,18 +376,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -425,18 +398,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -449,18 +420,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -473,18 +442,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -497,18 +464,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -521,18 +486,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -545,336 +508,314 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message is longer than 72 chars 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -887,18 +828,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -911,18 +850,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -935,18 +872,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -959,18 +894,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -983,18 +916,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1007,18 +938,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1031,18 +960,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1055,18 +982,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1079,392 +1004,368 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1477,18 +1378,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1501,18 +1400,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1525,18 +1422,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1549,18 +1444,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1573,18 +1466,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1597,18 +1488,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1621,18 +1510,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1645,18 +1532,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -1669,336 +1554,314 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message is longer than 72 chars 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2011,18 +1874,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2035,18 +1896,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2059,18 +1918,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2083,18 +1940,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2107,18 +1962,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2131,18 +1984,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2155,18 +2006,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2179,18 +2028,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2203,392 +2050,368 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2601,18 +2424,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2625,18 +2446,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2649,18 +2468,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2673,18 +2490,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2697,18 +2512,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2721,18 +2534,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2745,18 +2556,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2769,18 +2578,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -2793,336 +2600,314 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message is longer than 72 chars 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3135,18 +2920,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3159,18 +2942,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3183,18 +2964,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3207,18 +2986,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3231,18 +3008,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3255,18 +3030,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3279,18 +3052,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3303,18 +3074,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3327,392 +3096,368 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3725,18 +3470,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3749,18 +3492,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3773,18 +3514,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3797,18 +3536,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3821,18 +3558,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3845,18 +3580,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3869,18 +3602,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3893,18 +3624,16 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -3917,336 +3646,314 @@ The PR title format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message is longer than 72 chars 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4259,18 +3966,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4283,18 +3988,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4307,18 +4010,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4331,18 +4032,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4355,18 +4054,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4379,18 +4076,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4403,18 +4098,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4427,18 +4120,16 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message format is not according to our format.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The issue reference is not as per the format.
+- The issue reference must be formatted as follows:
 
   If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
 
@@ -4451,47 +4142,44 @@ The first commit message format is not according to our format.
   \`\`\`
 
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
-
-- The commit message tag doesnt match the tags mentioned below
+- The commit message tag must be one of the following:
 
   The \`Tag\` is one of the following:
 
   - Fix - for a bug fix.
   - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implemented a new feature.
+  - New - implements a new feature.
   - Breaking - for a backwards-incompatible enhancement or feature.
   - Docs - changes to documentation only.
   - Build - changes to build process only.
   - Upgrade - for a dependency upgrade.
-  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
 
-  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
 
-- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The first letter of the tag should be in uppercase
 
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
 exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The PR title format is not according to our format.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-#### Here are the following errors
+- The length of the commit message must be less than or equal to 72
 
-- The lenght of the commit message should be less than or equal to 72
-
-Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;

--- a/tests/plugins/commit-message/__snapshots__/index.js.snap
+++ b/tests/plugins/commit-message/__snapshots__/index.js.snap
@@ -1,0 +1,4497 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if commit message is not correct 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message is longer than 72 chars 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is too long 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if commit message is not correct 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message is longer than 72 chars 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is too long 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if commit message is not correct 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message is longer than 72 chars 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is too long 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if commit message is not correct 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message is longer than 72 chars 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The first commit message format is not according to our format.
+
+#### Here are the following errors
+
+- The issue reference is not as per the format.
+
+  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
+
+  Here are some good commit message summary examples:
+
+  \`\`\`
+  Build: Update Travis to only test Node 0.10 (refs #734)
+  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
+  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
+  \`\`\`
+
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The commit message tag doesnt match the tags mentioned below
+
+  The \`Tag\` is one of the following:
+
+  - Fix - for a bug fix.
+  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+  - New - implemented a new feature.
+  - Breaking - for a backwards-incompatible enhancement or feature.
+  - Docs - changes to documentation only.
+  - Build - changes to build process only.
+  - Upgrade - for a dependency upgrade.
+  - Chore - for refactoring, adding tests, etc. (anything that isn't user-facing).
+
+  Use the [labels of the issue you are working](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) on to determine the best tag.
+
+- There should be only one whitespace after tag followed by colon i.e \`<tag>: \`.
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
+
+exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is too long 1`] = `
+"Hi @user-a!, thanks for the Pull Request
+
+The PR title format is not according to our format.
+
+#### Here are the following errors
+
+- The lenght of the commit message should be less than or equal to 72
+
+Read more about contributing to Eslint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;

--- a/tests/plugins/commit-message/index.js
+++ b/tests/plugins/commit-message/index.js
@@ -60,7 +60,10 @@ function emitBotEvent(bot, payload = {}) {
                 id: 1
             },
             pull_request: {
-                number: 1
+                number: 1,
+                user: {
+                    login: "user-a"
+                }
             },
             sender: {
                 login: "user-a"
@@ -107,8 +110,16 @@ describe("commit-message", () => {
                     .post("/repos/test/repo-test/statuses/first-sha", req => req.state === "failure")
                     .reply(201);
 
+                const nockScope2 = nock("https://api.github.com")
+                    .post("/repos/test/repo-test/issues/1/comments", req => {
+                        expect(req.body).toMatchSnapshot();
+                        return true;
+                    })
+                    .reply(200);
+
                 await emitBotEvent(bot, { action });
                 expect(nockScope.isDone()).toBeTruthy();
+                expect(nockScope2.isDone()).toBeTruthy();
             });
 
             test("Posts success status if commit message is correct", async() => {
@@ -140,8 +151,16 @@ describe("commit-message", () => {
                     .post("/repos/test/repo-test/statuses/first-sha", req => req.state === "failure")
                     .reply(201);
 
+                const nockScope2 = nock("https://api.github.com")
+                    .post("/repos/test/repo-test/issues/1/comments", req => {
+                        expect(req.body).toMatchSnapshot();
+                        return true;
+                    })
+                    .reply(200);
+
                 await emitBotEvent(bot, { action });
                 expect(nockScope.isDone()).toBeTruthy();
+                expect(nockScope2.isDone()).toBeTruthy();
             });
 
             test("Posts success status if the commit message is longer than 72 chars after the newline", async() => {
@@ -175,8 +194,16 @@ describe("commit-message", () => {
                     .post("/repos/test/repo-test/statuses/second-sha", req => req.state === "failure")
                     .reply(201);
 
-                await emitBotEvent(bot, { action, pull_request: { number: 1, title: "foo" } });
+                const nockScope2 = nock("https://api.github.com")
+                    .post("/repos/test/repo-test/issues/1/comments", req => {
+                        expect(req.body).toMatchSnapshot();
+                        return true;
+                    })
+                    .reply(200);
+
+                await emitBotEvent(bot, { action, pull_request: { number: 1, title: "foo", user: { login: "user-a" } } });
                 expect(nockScope.isDone()).toBeTruthy();
+                expect(nockScope2.isDone()).toBeTruthy();
             });
 
             test("Posts failure status if there are multiple commit messages and the title is too long", async() => {
@@ -186,8 +213,16 @@ describe("commit-message", () => {
                     .post("/repos/test/repo-test/statuses/second-sha", req => req.state === "failure")
                     .reply(201);
 
-                await emitBotEvent(bot, { action, pull_request: { number: 1, title: `Update: ${"A".repeat(72)}` } });
+                const nockScope2 = nock("https://api.github.com")
+                    .post("/repos/test/repo-test/issues/1/comments", req => {
+                        expect(req.body).toMatchSnapshot();
+                        return true;
+                    })
+                    .reply(200);
+
+                await emitBotEvent(bot, { action, pull_request: { number: 1, title: `Update: ${"A".repeat(72)}`, user: { login: "user-a" } } });
                 expect(nockScope.isDone()).toBeTruthy();
+                expect(nockScope2.isDone()).toBeTruthy();
             });
 
             // Tests for invalid or malformed tag prefixes
@@ -213,8 +248,16 @@ describe("commit-message", () => {
                         .post("/repos/test/repo-test/statuses/first-sha", req => req.state === "failure")
                         .reply(201);
 
+                    const nockScope2 = nock("https://api.github.com")
+                        .post("/repos/test/repo-test/issues/1/comments", req => {
+                            expect(req.body).toMatchSnapshot();
+                            return true;
+                        })
+                        .reply(200);
+
                     await emitBotEvent(bot, { action });
                     expect(nockScope.isDone()).toBeTruthy();
+                    expect(nockScope2.isDone()).toBeTruthy();
                 });
 
                 test(`Posts failure status if PR with multiple commits has invalid tag prefix in the title: "${prefix}"`, async() => {
@@ -224,8 +267,16 @@ describe("commit-message", () => {
                         .post("/repos/test/repo-test/statuses/second-sha", req => req.state === "failure")
                         .reply(201);
 
-                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: message } });
+                    const nockScope2 = nock("https://api.github.com")
+                        .post("/repos/test/repo-test/issues/1/comments", req => {
+                            expect(req.body).toMatchSnapshot();
+                            return true;
+                        })
+                        .reply(200);
+
+                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: message, user: { login: "user-a" } } });
                     expect(nockScope.isDone()).toBeTruthy();
+                    expect(nockScope2.isDone()).toBeTruthy();
                 });
             });
 
@@ -290,8 +341,16 @@ describe("commit-message", () => {
                         .post("/repos/test/repo-test/statuses/first-sha", req => req.state === "failure")
                         .reply(201);
 
+                    const nockScope2 = nock("https://api.github.com")
+                        .post("/repos/test/repo-test/issues/1/comments", req => {
+                            expect(req.body).toMatchSnapshot();
+                            return true;
+                        })
+                        .reply(200);
+
                     await emitBotEvent(bot, { action });
                     expect(nockScope.isDone()).toBeTruthy();
+                    expect(nockScope2.isDone()).toBeTruthy();
                 });
 
                 test(`Posts failure status if multiple commits and PR title references issue improperly: ${suffix}`, async() => {
@@ -301,8 +360,16 @@ describe("commit-message", () => {
                         .post("/repos/test/repo-test/statuses/second-sha", req => req.state === "failure")
                         .reply(201);
 
-                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: `New: foo ${suffix}` } });
+                    const nockScope2 = nock("https://api.github.com")
+                        .post("/repos/test/repo-test/issues/1/comments", req => {
+                            expect(req.body).toMatchSnapshot();
+                            return true;
+                        })
+                        .reply(200);
+
+                    await emitBotEvent(bot, { action, pull_request: { number: 1, title: `New: foo ${suffix}`, user: { login: "user-a" } } });
                     expect(nockScope.isDone()).toBeTruthy();
+                    expect(nockScope2.isDone()).toBeTruthy();
                 });
             });
 


### PR DESCRIPTION
Fixes #127, fixes #64

This change will comment on the PR with the errors and its details. 

#### Question to reviewers 

- Currently, I am using snapshot testing for the assertion of the comment body, is it fine or do I need to change with the something which may be preferred by others?
- the error explanation is a hardcoded message. Mostly copied from the contribution guide. Should I add a script which will fetch from those source documents and write it to a file and from there we will use for the error details/explanation. 