### PR TITLE
Chore: Move bot to Dokku and create auto-deploy workflow (fixes #109)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+---
+name: 'deploy'
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          git_remote_url: 'ssh://dokku@github-bot.eslint.org/eslint-github-bot'
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ To add a plugin:
 1. Create the plugin as a new file in `src/plugins`.
 1. Add the plugin to the list in `src/plugins/index.js`.
 1. Add the plugin to the list in `src/app.js` to enable it by default.
+
+## Deployment
+
+The bot is deployed to a [Dokku](https://dokku.com) instance named github-bot.eslint.org and is installed as a GitHub Application at the organization level.


### PR DESCRIPTION
I've deployed the bot to Dokku already, and this update creates a GitHub action that will automatically deploy to Dokku whenever a PR is merged to the master branch. 