### PR TITLE
New: Add new issues to triage project (refs #136)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,7 @@ const bot = probot.createProbot({
     id: process.env.APP_ID
 });
 const enabledPlugins = new Set([
+    "addToTriageProject",
     "autoCloser",
     "commitMessage",
     "issueArchiver",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview Shared constants for the bot
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+module.exports = {
+    NEEDS_TRIAGE_COLUMN_ID: 11153344
+};

--- a/src/plugins/add-to-triage-project/index.js
+++ b/src/plugins/add-to-triage-project/index.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Adds a newly opened issue to the Triage project
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+const { NEEDS_TRIAGE_COLUMN_ID } = require("../../constants");
+
+/**
+ * Adds the issue to the triage project.
+ * @param {Context} context Probot webhook event context
+ * @returns {Promise<void>} A Promise that fulfills when the action is complete
+ * @private
+ */
+async function triage(context) {
+
+    const issue = context.payload.issue;
+
+    await context.github.projects.createCard({
+        column_id: NEEDS_TRIAGE_COLUMN_ID,
+        content_id: issue.id,
+        content_type: "Issue"
+    });
+}
+
+module.exports = robot => {
+    robot.on("issues.opened", triage);
+};

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -13,6 +13,7 @@
  */
 
 module.exports = {
+    addToTriageProject: require("./add-to-triage-project"),
     autoCloser: require("./auto-closer"),
     checkUnitTest: require("./check-unit-test"),
     commitMessage: require("./commit-message"),

--- a/tests/plugins/add-to-triage-project/index.js
+++ b/tests/plugins/add-to-triage-project/index.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const { addToTriageProject } = require("../../../src/plugins/index");
+const nock = require("nock");
+const { Application } = require("probot");
+const { NEEDS_TRIAGE_COLUMN_ID } = require("../../../src/constants");
+const GitHubApi = require("@octokit/rest");
+
+describe("add-to-triage-project", () => {
+    let bot = null;
+
+    beforeAll(() => {
+        bot = new Application({
+            id: "test",
+            cert: "test",
+            cache: {
+                wrap: () => Promise.resolve({ data: { token: "test" } })
+            }
+        });
+        bot.auth = () => new GitHubApi();
+        addToTriageProject(bot);
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    describe("issue opened", () => {
+        test("Adds the issue to the projectt", async() => {
+            const addIssueToTriageProject = nock("https://api.github.com")
+                .post(`/projects/columns/${NEEDS_TRIAGE_COLUMN_ID}/cards`, body => {
+                    expect(body).toEqual({
+                        content_id: 1234,
+                        content_type: "Issue"
+                    });
+                    return true;
+                })
+                .reply(200);
+
+            await bot.receive({
+                name: "issues",
+                payload: {
+                    action: "opened",
+                    installation: {
+                        id: 1
+                    },
+                    issue: {
+                        labels: [],
+                        number: 1,
+                        id: 1234
+                    },
+                    repository: {
+                        name: "repo-test",
+                        owner: {
+                            login: "test"
+                        }
+                    }
+                }
+            });
+
+            expect(addIssueToTriageProject.isDone()).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
This change automatically adds new issues to the first column of the Triage project so we don't have to do it manually

First item in #136