### PR TITLE
Update: Don't add auto-created issues to triage board (fixes #147)

### DIFF
--- a/src/plugins/add-to-triage-project/index.js
+++ b/src/plugins/add-to-triage-project/index.js
@@ -17,6 +17,11 @@ async function triage(context) {
 
     const issue = context.payload.issue;
 
+    // issues with "triage:no" label are exempt
+    if (issue.labels.some(label => label.name === "triage:no")) {
+        return;
+    }
+
     await context.github.projects.createCard({
         column_id: NEEDS_TRIAGE_COLUMN_ID,
         content_id: issue.id,

--- a/src/plugins/recurring-issues/index.js
+++ b/src/plugins/recurring-issues/index.js
@@ -217,7 +217,7 @@ function createIssueHandler({ labelTrigger, newLabels, shouldCreateNewIssue, get
 const RELEASE_ISSUE_TITLE_FORMAT = "[Scheduled release for ]MMMM Do, YYYY";
 const releaseIssueHandler = createIssueHandler({
     labelTrigger: "release",
-    newLabels: ["release", "tsc agenda"],
+    newLabels: ["release", "tsc agenda", "triage:no"],
     async shouldCreateNewIssue({ title }) {
         return moment.utc(title, RELEASE_ISSUE_TITLE_FORMAT, true).isValid();
     },
@@ -235,7 +235,7 @@ const releaseIssueHandler = createIssueHandler({
 const TSC_MEETING_TITLE_FORMAT = "[TSC meeting ]DD-MMMM-YYYY";
 const tscMeetingIssueHandler = createIssueHandler({
     labelTrigger: "tsc meeting",
-    newLabels: ["tsc meeting"],
+    newLabels: ["tsc meeting", "triage:no"],
     async shouldCreateNewIssue({ title }) {
         return moment.utc(title, TSC_MEETING_TITLE_FORMAT, true).isValid();
     },

--- a/tests/plugins/add-to-triage-project/index.js
+++ b/tests/plugins/add-to-triage-project/index.js
@@ -63,7 +63,15 @@ describe("add-to-triage-project", () => {
 
         test("doesn't add the issue to the project when 'triage:no' label is present", async() => {
 
-            // no nock because we don't want any API calls
+            const addIssueToTriageProject = nock("https://api.github.com")
+                .post(`/projects/columns/${NEEDS_TRIAGE_COLUMN_ID}/cards`, body => {
+                    expect(body).toEqual({
+                        content_id: 1234,
+                        content_type: "Issue"
+                    });
+                    return true;
+                })
+                .reply(200);
 
             await bot.receive({
                 name: "issues",
@@ -89,6 +97,8 @@ describe("add-to-triage-project", () => {
                     }
                 }
             });
+
+            expect(addIssueToTriageProject.isDone()).toBeFalsy();
 
         });
     });

--- a/tests/plugins/add-to-triage-project/index.js
+++ b/tests/plugins/add-to-triage-project/index.js
@@ -26,7 +26,7 @@ describe("add-to-triage-project", () => {
     });
 
     describe("issue opened", () => {
-        test("Adds the issue to the projectt", async() => {
+        test("Adds the issue to the project", async() => {
             const addIssueToTriageProject = nock("https://api.github.com")
                 .post(`/projects/columns/${NEEDS_TRIAGE_COLUMN_ID}/cards`, body => {
                     expect(body).toEqual({
@@ -59,6 +59,37 @@ describe("add-to-triage-project", () => {
             });
 
             expect(addIssueToTriageProject.isDone()).toBeTruthy();
+        });
+
+        test("doesn't add the issue to the project when 'triage:no' label is present", async() => {
+
+            // no nock because we don't want any API calls
+
+            await bot.receive({
+                name: "issues",
+                payload: {
+                    action: "opened",
+                    installation: {
+                        id: 1
+                    },
+                    issue: {
+                        labels: [
+                            {
+                                name: "triage:no"
+                            }
+                        ],
+                        number: 1,
+                        id: 1234
+                    },
+                    repository: {
+                        name: "repo-test",
+                        owner: {
+                            login: "test"
+                        }
+                    }
+                }
+            });
+
         });
     });
 });


### PR DESCRIPTION
I added a new "triage:no" label that the bot uses to determine not to include an issue on the triage board.