### PR TITLE
Update: needs info label behavior (refs #136)

### DIFF
--- a/src/plugins/needs-info/index.js
+++ b/src/plugins/needs-info/index.js
@@ -41,7 +41,7 @@ function hasNeedInfoLabel(label) {
 async function check(context) {
     const { payload, github } = context;
 
-    if (hasNeedInfoLabel(payload.label)) {
+    if (payload.issue.labels.some(hasNeedInfoLabel)) {
         await github.issues.createComment(context.issue({
             body: commentMessage(payload.issue.user.login)
         }));

--- a/src/plugins/needs-info/index.js
+++ b/src/plugins/needs-info/index.js
@@ -9,26 +9,14 @@ const needInfoLabel = "needs info";
 
 /**
  * Create the comment for the need info
- * @param {string} username - user to tag on the comment
  * @returns {string} comment message
  * @private
  */
-function commentMessage(username) {
+function commentMessage() {
     return `
-Hi @${username}, thanks for the issue. It looks like there's not enough information for us to know how to help you.
+It looks like there wasn't enough information for us to know how to help you, so we're closing the issue.
 
-If you're reporting a bug, please be sure to include:
-
-1. The version of ESLint you are using (run \`eslint -v\`)
-2. What you did (the source code and ESLint configuration)
-3. The actual ESLint output complete with numbers
-4. What you expected to happen instead
-
-Requesting a new rule? Please see [Proposing a New Rule](http://eslint.org/docs/developer-guide/contributing/new-rules) for instructions.
-
-Requesting a rule change? Please see [Proposing a Rule Change](http://eslint.org/docs/developer-guide/contributing/rule-changes) for instructions.
-
-If it's something else, please just provide as much additional information as possible. Thanks!
+Thanks for your understanding.
 
 [//]: # (needs-info)
 `;
@@ -65,5 +53,5 @@ async function check(context) {
  */
 
 module.exports = robot => {
-    robot.on("issues.labeled", check);
+    robot.on("issues.closed", check);
 };

--- a/src/plugins/needs-info/index.js
+++ b/src/plugins/needs-info/index.js
@@ -43,7 +43,7 @@ async function check(context) {
 
     if (payload.issue.labels.some(hasNeedInfoLabel)) {
         await github.issues.createComment(context.issue({
-            body: commentMessage(payload.issue.user.login)
+            body: commentMessage()
         }));
     }
 }

--- a/tests/plugins/needs-info/index.js
+++ b/tests/plugins/needs-info/index.js
@@ -51,9 +51,6 @@ describe("needs-info", () => {
                         },
                         number: 1
                     },
-                    label: {
-                        name: "needs info"
-                    },
                     repository: {
                         name: "repo-test",
                         owner: {
@@ -84,9 +81,6 @@ describe("needs-info", () => {
                             login: "user-a"
                         },
                         number: 1
-                    },
-                    label: {
-                        name: "triage"
                     },
                     repository: {
                         name: "repo-test",

--- a/tests/plugins/needs-info/index.js
+++ b/tests/plugins/needs-info/index.js
@@ -36,7 +36,7 @@ describe("needs-info", () => {
             await bot.receive({
                 name: "issues",
                 payload: {
-                    action: "labeled",
+                    action: "closed",
                     installation: {
                         id: 1
                     },
@@ -70,7 +70,7 @@ describe("needs-info", () => {
             await bot.receive({
                 name: "issues",
                 payload: {
-                    action: "labeled",
+                    action: "closed",
                     installation: {
                         id: 1
                     },


### PR DESCRIPTION
Changes the "needs info" label behavior so it doesn't autocomment, but instead, will comment when an issued is closed with the "needs info" label.