### PR TITLE
Update: Switch to conventional commits

### DIFF
--- a/src/plugins/commit-message/createMessage.js
+++ b/src/plugins/commit-message/createMessage.js
@@ -8,36 +8,10 @@
 const MESSAGE_LENGTH_LIMIT = 72;
 
 const ERROR_MESSAGES = {
-    SPACE_AFTER_TAG_COLON: "- There should be a space following the initial tag and colon, for example 'New: Message'.",
-    NON_UPPERCASE_FIRST_LETTER_TAG: "- The first letter of the tag should be in uppercase",
-    NON_MATCHED_TAG: `- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-`,
-    LONG_MESSAGE: `- The length of the commit message must be less than or equal to ${MESSAGE_LENGTH_LIMIT}`,
-    WRONG_REF: `- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-`
+    SPACE_AFTER_TAG_COLON: "- There should be a space following the initial tag and colon, for example 'feat: Message'.",
+    NON_LOWERCASE_FIRST_LETTER_TAG: "- The first letter of the tag should be in lowercase",
+    NON_MATCHED_TAG: "- The commit message tag wasn't recognized. Did you mean \"docs\", \"fix\", or \"feat\"?",
+    LONG_MESSAGE: `- The length of the commit message must be less than or equal to ${MESSAGE_LENGTH_LIMIT}`
 };
 
 /**

--- a/src/plugins/commit-message/index.js
+++ b/src/plugins/commit-message/index.js
@@ -9,16 +9,11 @@
 const { getCommitMessageForPR } = require("../utils");
 const commentMessage = require("./createMessage");
 
-const TAG_REGEX = /^(?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade): /;
+const TAG_REGEX = /^(?:feat|build|chore|docs|fix|refactor|test|ci|perf)!?: /;
 
-const TAG_SPACE_REGEX = /^(?:[A-Z][a-z]+: )/;
+const TAG_SPACE_REGEX = /^(?:[a-z]+!?: )/;
 
-const UPPERCASE_TAG_REGEX = /^[A-Z]/;
-
-const POTENTIAL_ISSUE_REF_REGEX = /#\d+/;
-
-const VALID_ISSUE_REF = "(?:(?:fixes|refs) (?:[^/]+[/][^/]+)?#\\d+)";
-const CORRECT_ISSUE_REF_REGEX = new RegExp(` \\(${VALID_ISSUE_REF}(?:, ${VALID_ISSUE_REF})*\\)$`);
+const LOWERCASE_TAG_REGEX = /^[a-z]/;
 
 const MESSAGE_LENGTH_LIMIT = 72;
 
@@ -51,22 +46,12 @@ function getCommitMessageErrors(message) {
         errors.push("SPACE_AFTER_TAG_COLON");
     }
 
-    if (!UPPERCASE_TAG_REGEX.test(commitTitle)) {
-        errors.push("NON_UPPERCASE_FIRST_LETTER_TAG");
+    if (!LOWERCASE_TAG_REGEX.test(commitTitle)) {
+        errors.push("NON_LOWERCASE_FIRST_LETTER_TAG");
     }
 
     if (!(commitTitle.length <= MESSAGE_LENGTH_LIMIT)) {
         errors.push("LONG_MESSAGE");
-    }
-
-    // Then, if there appears to be an issue reference, test for correctness
-    if (errors.length === 0 && POTENTIAL_ISSUE_REF_REGEX.test(commitTitle)) {
-        const issueSuffixMatch = CORRECT_ISSUE_REF_REGEX.exec(commitTitle);
-
-        // If no suffix, or issue ref occurs before suffix, message is invalid
-        if (!issueSuffixMatch || POTENTIAL_ISSUE_REF_REGEX.test(commitTitle.slice(0, issueSuffixMatch.index))) {
-            errors.push("WRONG_REF");
-        }
     }
 
     return errors;

--- a/tests/plugins/commit-message/__snapshots__/index.js.snap
+++ b/tests/plugins/commit-message/__snapshots__/index.js.snap
@@ -5,23 +5,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -32,23 +18,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -59,21 +31,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -84,22 +44,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -110,48 +57,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -162,22 +70,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -188,21 +83,9 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -213,21 +96,21 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -238,23 +121,8 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -265,23 +133,7 @@ exports[`commit-message pull request edited Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -292,221 +144,8 @@ exports[`commit-message pull request edited Posts failure status if commit messa
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -517,23 +156,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -544,23 +169,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -571,21 +182,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -596,22 +195,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -622,48 +208,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -674,22 +221,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -700,21 +234,9 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -725,21 +247,21 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -750,23 +272,8 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -777,23 +284,7 @@ exports[`commit-message pull request edited Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -810,226 +301,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 "
 `;
 
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request edited Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
 exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1051,23 +329,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1078,23 +342,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1105,21 +355,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1130,22 +368,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1156,48 +381,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1208,22 +394,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1234,21 +407,9 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1259,21 +420,21 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1284,23 +445,8 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1311,23 +457,7 @@ exports[`commit-message pull request opened Posts failure status if PR with mult
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1338,221 +468,8 @@ exports[`commit-message pull request opened Posts failure status if commit messa
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1563,23 +480,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1590,23 +493,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1617,21 +506,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1642,22 +519,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1668,48 +532,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1720,22 +545,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1746,21 +558,9 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1771,21 +571,21 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1796,23 +596,8 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1823,23 +608,7 @@ exports[`commit-message pull request opened Posts failure status if the commit m
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1856,226 +625,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 "
 `;
 
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request opened Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
 exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2097,23 +653,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2124,23 +666,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2151,21 +679,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2176,22 +692,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2202,48 +705,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2254,22 +718,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2280,21 +731,9 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2305,21 +744,21 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2330,23 +769,8 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2357,23 +781,7 @@ exports[`commit-message pull request reopened Posts failure status if PR with mu
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2384,221 +792,8 @@ exports[`commit-message pull request reopened Posts failure status if commit mes
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2609,23 +804,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2636,23 +817,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2663,21 +830,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2688,22 +843,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2714,48 +856,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2766,22 +869,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2792,21 +882,9 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2817,21 +895,21 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2842,23 +920,8 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2869,23 +932,7 @@ exports[`commit-message pull request reopened Posts failure status if the commit
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -2902,226 +949,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 "
 `;
 
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request reopened Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
 exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3143,23 +977,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3170,23 +990,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3197,21 +1003,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3222,22 +1016,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3248,48 +1029,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3300,22 +1042,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3326,21 +1055,9 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3351,21 +1068,21 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3376,23 +1093,8 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3403,23 +1105,7 @@ exports[`commit-message pull request synchronize Posts failure status if PR with
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3430,221 +1116,8 @@ exports[`commit-message pull request synchronize Posts failure status if commit 
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if multiple commits and PR title references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3655,23 +1128,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3682,23 +1141,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3709,21 +1154,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3734,22 +1167,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3760,48 +1180,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New" 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3812,22 +1193,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3838,21 +1206,9 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3863,21 +1219,21 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
+- The first letter of the tag should be in lowercase
 
-  The \`Tag\` is one of the following:
+Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+"
+`;
 
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
+exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
+"Hi @user-a!, thanks for the Pull Request
 
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
+The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3888,23 +1244,8 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3915,23 +1256,7 @@ exports[`commit-message pull request synchronize Posts failure status if the com
 
 The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -3948,226 +1273,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 "
 `;
 
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: #1 (fixes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (closes #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fix #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fixes #1, #2) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (fixes eslint#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (ref #1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: (refs eslint/nested/group#1) 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
-exports[`commit-message pull request synchronize Posts failure status if the commit message references issue improperly: fixes #1 1`] = `
-"Hi @user-a!, thanks for the Pull Request
-
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
-
-- The issue reference must be formatted as follows:
-
-  If the pull request addresses an issue, then the issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use \`(refs #1234)\` instead of \`(fixes #1234)\`.
-
-  Here are some good commit message summary examples:
-
-  \`\`\`
-  Build: Update Travis to only test Node 0.10 (refs #734)
-  Fix: Semi rule incorrectly flagging extra semicolon (fixes #840)
-  Upgrade: Esprima to 1.2, switch to using comment attachment (fixes #730)
-  \`\`\`
-
-
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
-"
-`;
-
 exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
 The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
-- The commit message tag must be one of the following:
-
-  The \`Tag\` is one of the following:
-
-  - Fix - for a bug fix.
-  - Update - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
-  - New - implements a new feature.
-  - Breaking - for a backwards-incompatible enhancement or feature.
-  - Docs - changes to documentation only.
-  - Build - changes to build process only.
-  - Upgrade - for a dependency upgrade.
-  - Chore - for anything that isn't user-facing (for example, refactoring, adding tests, etc.).
-
-  You can use the [labels of the issue you are working on](https://eslint.org/docs/developer-guide/contributing/working-on-issues#issue-labels) to determine the best tag.
-
-- There should be a space following the initial tag and colon, for example 'New: Message'.
-- The first letter of the tag should be in uppercase
+- The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+- There should be a space following the initial tag and colon, for example 'feat: Message'.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "


### PR DESCRIPTION
This changes the bot to check for conventional commits instead of our old-style commits.

Refs https://github.com/eslint/eslint/issues/14231