### PR TITLE
feat: Automatically add PR labels based on commit

### DIFF
--- a/src/plugins/commit-message/createMessage.js
+++ b/src/plugins/commit-message/createMessage.js
@@ -33,9 +33,11 @@ module.exports = function commentMessage(errors = [], isTitle = false, username)
 
     return `Hi @${username}!, thanks for the Pull Request
 
-The ${isTitle ? "pull request title" : "first commit message"} isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **${isTitle ? "pull request title" : "first commit message"}** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 ${errorMessages.join("\n")}
+
+**To Fix:** You can fix this problem by ${isTitle ? "clicking 'Edit' next to the pull request title at the top of this page." : "By running `git commit --amend`, editing your commit message, and then running `git push -f` to update this pull request."}
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 `;

--- a/src/plugins/commit-message/createMessage.js
+++ b/src/plugins/commit-message/createMessage.js
@@ -37,7 +37,7 @@ The **${isTitle ? "pull request title" : "first commit message"}** isn't properl
 
 ${errorMessages.join("\n")}
 
-**To Fix:** You can fix this problem by ${isTitle ? "clicking 'Edit' next to the pull request title at the top of this page." : "By running `git commit --amend`, editing your commit message, and then running `git push -f` to update this pull request."}
+**To Fix:** You can fix this problem by ${isTitle ? "clicking 'Edit' next to the pull request title at the top of this page." : "running `git commit --amend`, editing your commit message, and then running `git push -f` to update this pull request."}
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 `;

--- a/src/plugins/commit-message/util.js
+++ b/src/plugins/commit-message/util.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Shared data for plugin and tests of commit-message
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+exports.TAG_LABELS = new Map([
+    ["feat:", ["feature"]],
+    ["feat!:", ["feature", "breaking"]],
+    ["build:", ["build"]],
+    ["chore:", ["chore"]],
+    ["docs:", ["documentation"]],
+    ["fix:", ["bug"]],
+    ["fix!:", ["bug", "breaking"]],
+    ["refactor:", ["chore"]],
+    ["test:", ["chore"]],
+    ["ci:", ["build"]],
+    ["perf:", ["chore"]]
+]);

--- a/tests/plugins/commit-message/__snapshots__/index.js.snap
+++ b/tests/plugins/commit-message/__snapshots__/index.js.snap
@@ -3,11 +3,13 @@
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -16,11 +18,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -29,11 +33,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -42,11 +48,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -55,11 +63,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -68,11 +78,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -81,11 +93,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -94,11 +108,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -107,10 +123,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -119,10 +137,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -131,9 +151,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -142,10 +164,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -154,11 +178,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -167,11 +193,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -180,11 +208,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -193,11 +223,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -206,11 +238,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -219,11 +253,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -232,11 +268,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -245,11 +283,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -258,10 +298,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -270,10 +312,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -282,20 +326,24 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
-exports[`commit-message pull request edited Posts failure status if the commit message is longer than 72 chars 1`] = `
+exports[`commit-message pull request edited Posts failure status if the commit message is longer than 72 chars and don't set labels 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -304,10 +352,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -316,9 +366,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request edited Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -327,11 +379,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -340,11 +394,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -353,11 +409,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -366,11 +424,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -379,11 +439,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -392,11 +454,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -405,11 +469,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -418,11 +484,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -431,10 +499,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -443,10 +513,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -455,9 +527,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -466,10 +540,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -478,11 +554,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -491,11 +569,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -504,11 +584,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -517,11 +599,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -530,11 +614,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -543,11 +629,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -556,11 +644,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -569,11 +659,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -582,10 +674,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -594,10 +688,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -606,20 +702,24 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
-exports[`commit-message pull request opened Posts failure status if the commit message is longer than 72 chars 1`] = `
+exports[`commit-message pull request opened Posts failure status if the commit message is longer than 72 chars and don't set labels 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -628,10 +728,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -640,9 +742,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request opened Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -651,11 +755,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -664,11 +770,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -677,11 +785,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -690,11 +800,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -703,11 +815,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -716,11 +830,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -729,11 +845,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -742,11 +860,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -755,10 +875,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -767,10 +889,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -779,9 +903,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -790,10 +916,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -802,11 +930,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -815,11 +945,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -828,11 +960,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -841,11 +975,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -854,11 +990,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -867,11 +1005,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -880,11 +1020,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -893,11 +1035,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -906,10 +1050,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -918,10 +1064,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -930,20 +1078,24 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
-exports[`commit-message pull request reopened Posts failure status if the commit message is longer than 72 chars 1`] = `
+exports[`commit-message pull request reopened Posts failure status if the commit message is longer than 72 chars and don't set labels 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -952,10 +1104,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -964,9 +1118,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request reopened Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -975,11 +1131,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -988,11 +1146,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1001,11 +1161,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1014,11 +1176,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1027,11 +1191,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1040,11 +1206,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1053,11 +1221,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1066,11 +1236,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1079,10 +1251,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1091,10 +1265,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1103,9 +1279,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if PR with multiple commits has invalid tag prefix in the title: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1114,10 +1292,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if commit message is not correct 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1126,11 +1306,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: " New: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1139,11 +1321,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: ": " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1152,11 +1336,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Foo: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1165,11 +1351,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1178,11 +1366,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New : " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1191,11 +1381,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "New:" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1204,11 +1396,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Neww: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1217,11 +1411,13 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "Revert: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1230,10 +1426,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "feat" 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1242,10 +1440,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "nNew: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1254,20 +1454,24 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if the commit message has invalid tag prefix: "new: " 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
 `;
 
-exports[`commit-message pull request synchronize Posts failure status if the commit message is longer than 72 chars 1`] = `
+exports[`commit-message pull request synchronize Posts failure status if the commit message is longer than 72 chars and don't set labels 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The first commit message isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **first commit message** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1276,10 +1480,12 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is invalid 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1288,9 +1494,11 @@ Read more about contributing to ESLint [here](https://eslint.org/docs/developer-
 exports[`commit-message pull request synchronize Posts failure status if there are multiple commit messages and the title is too long 1`] = `
 "Hi @user-a!, thanks for the Pull Request
 
-The pull request title isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
+The **pull request title** isn't properly formatted. We ask that you update the message to match this format, as we use it to generate changelogs and automate releases.
 
 - The length of the commit message must be less than or equal to 72
+
+**To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "

--- a/tests/plugins/commit-message/__snapshots__/index.js.snap
+++ b/tests/plugins/commit-message/__snapshots__/index.js.snap
@@ -169,7 +169,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -184,7 +184,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -199,7 +199,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -214,7 +214,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -229,7 +229,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -244,7 +244,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -259,7 +259,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -274,7 +274,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -289,7 +289,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -303,7 +303,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -317,7 +317,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -330,7 +330,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -343,7 +343,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The length of the commit message must be less than or equal to 72
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -545,7 +545,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -560,7 +560,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -575,7 +575,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -590,7 +590,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -605,7 +605,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -620,7 +620,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -635,7 +635,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -650,7 +650,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -665,7 +665,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -679,7 +679,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -693,7 +693,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -706,7 +706,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -719,7 +719,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The length of the commit message must be less than or equal to 72
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -921,7 +921,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -936,7 +936,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -951,7 +951,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -966,7 +966,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -981,7 +981,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -996,7 +996,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1011,7 +1011,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1026,7 +1026,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1041,7 +1041,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1055,7 +1055,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1069,7 +1069,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1082,7 +1082,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1095,7 +1095,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The length of the commit message must be less than or equal to 72
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1297,7 +1297,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1312,7 +1312,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1327,7 +1327,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1342,7 +1342,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1357,7 +1357,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1372,7 +1372,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1387,7 +1387,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1402,7 +1402,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1417,7 +1417,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 - The first letter of the tag should be in lowercase
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1431,7 +1431,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1445,7 +1445,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 - There should be a space following the initial tag and colon, for example 'feat: Message'.
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1458,7 +1458,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The commit message tag wasn't recognized. Did you mean \\"docs\\", \\"fix\\", or \\"feat\\"?
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "
@@ -1471,7 +1471,7 @@ The **first commit message** isn't properly formatted. We ask that you update th
 
 - The length of the commit message must be less than or equal to 72
 
-**To Fix:** You can fix this problem by By running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
+**To Fix:** You can fix this problem by running \`git commit --amend\`, editing your commit message, and then running \`git push -f\` to update this pull request.
 
 Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
 "

--- a/tests/plugins/commit-message/index.js
+++ b/tests/plugins/commit-message/index.js
@@ -205,11 +205,7 @@ describe("commit-message", () => {
                     .post("/repos/test/repo-test/statuses/second-sha", req => req.state === "success")
                     .reply(201);
 
-                const labelsScope = nock("https://api.github.com")
-                    .post("/repos/test/repo-test/issues/1/labels", {
-                        labels: ["feature"]
-                    })
-                    .reply(201);
+                const labelsScope = mockLabels(["feature"]);
 
                 await emitBotEvent(bot, { action, pull_request: { number: 1, title: "feat: foo" } });
                 expect(nockScope.isDone()).toBeTruthy();


### PR DESCRIPTION
This change ensures that pull requests will have appropriate tags added when the commit message is formatted correctly. Specifically:

* "feat" -> "feature"
* "feat!" -> "feature", "breaking"
* "fix" -> "bug"
* "fix!" -> "bug", "breaking"
* "chore" -> "chore"
* "build" -> "build"
* "test" -> "chore"