### PR TITLE
docs: update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/eslint/eslint-github-bot.svg?branch=master)](https://travis-ci.org/eslint/eslint-github-bot)
+[![Build Status](https://github.com/eslint/eslint-github-bot/workflows/CI/badge.svg)](https://github.com/eslint/eslint-github-bot/actions)
 
 ESLint GitHub bot
 ==========================


### PR DESCRIPTION
Updates the Build Status badge from Travis to GitHub Actions.