### PR TITLE
chore: Update release instructions for draft blog posts

### DIFF
--- a/src/plugins/recurring-issues/index.js
+++ b/src/plugins/recurring-issues/index.js
@@ -22,7 +22,9 @@ The next scheduled release will occur on ${releaseDate.format("dddd, MMMM Do, YY
 - [ ] Remove the 'tsc agenda' label on this issue
 - [ ] Review open pull requests and merge any that are [ready](https://eslint.org/docs/maintainer-guide/pullrequests#when-to-merge-a-pull-request)
 - [ ] Start the release on [Jenkins](https://jenkins.eslint.org)
-- [ ] Update the release blog post with a "Highlights" section
+- [ ] Update the release blog post:
+    - [ ] Add a "Highlights" section for any noteworthy changes.
+    - [ ] Remove the \`draft: true\` line in frontmatter.
 - [ ] Make a release announcement on Twitter
 - [ ] Make a release announcement in the Discord '#announcements' channel
 - [ ] Add a comment to this issue saying the release is out
@@ -43,7 +45,9 @@ Typically Monday for regular releases; two days after patch releases.
 
 - [ ] Resolve the regression by merging any necessary fixes
 - [ ] Start the release on [Jenkins](https://jenkins.eslint.org)
-- [ ] Update the release blog post with a "Highlights" section
+- [ ] Update the release blog post:
+    - [ ] Add a "Highlights" section for any noteworthy changes.
+    - [ ] Remove the \`draft: true\` line in frontmatter.
 - [ ] Make a release announcement on Twitter
 - [ ] Make a release announcement in the Discord '#announcements' channel
 - [ ] Add a comment to this issue saying the release is out

--- a/src/plugins/recurring-issues/index.js
+++ b/src/plugins/recurring-issues/index.js
@@ -24,6 +24,7 @@ The next scheduled release will occur on ${releaseDate.format("dddd, MMMM Do, YY
 - [ ] Start the release on [Jenkins](https://jenkins.eslint.org)
 - [ ] Update the release blog post:
     - [ ] Add a "Highlights" section for any noteworthy changes.
+    - [ ] In the \`authors\` frontmatter, replace \`eslintbot\` with your GitHub username.
     - [ ] Remove the \`draft: true\` line in frontmatter.
 - [ ] Make a release announcement on Twitter
 - [ ] Make a release announcement in the Discord '#announcements' channel
@@ -47,6 +48,7 @@ Typically Monday for regular releases; two days after patch releases.
 - [ ] Start the release on [Jenkins](https://jenkins.eslint.org)
 - [ ] Update the release blog post:
     - [ ] Add a "Highlights" section for any noteworthy changes.
+    - [ ] In the \`authors\` frontmatter, replace \`eslintbot\` with your GitHub username.
     - [ ] Remove the \`draft: true\` line in frontmatter.
 - [ ] Make a release announcement on Twitter
 - [ ] Make a release announcement in the Discord '#announcements' channel


### PR DESCRIPTION
Once https://github.com/eslint/eslint/pull/16130 is merged, release blog posts will be unpublished drafts by default and only published once the releaser adds the highlights.