### PR TITLE
chore: Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,6 @@ jobs:
       - name: Push to dokku
         uses: dokku/github-action@master
         with:
+          branch: main
           git_remote_url: 'ssh://dokku@github-bot.eslint.org/eslint-github-bot'
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
As best I can tell from the [docs](https://github.com/dokku/github-action#inputs), this seems like the fix to make the bot deploy to the correct branch.

Fixes #192 