### PR TITLE
fix: move `@eslint/js` release after other packages

### DIFF
--- a/src/plugins/recurring-issues/index.js
+++ b/src/plugins/recurring-issues/index.js
@@ -21,8 +21,8 @@ The next scheduled release will occur on ${releaseDate.format("dddd, MMMM Do, YY
 
 - [ ] Remove the 'tsc agenda' label on this issue
 - [ ] Review open pull requests and merge any that are [ready](https://eslint.org/docs/maintainer-guide/pullrequests#when-to-merge-a-pull-request)
-- [ ] Release \`@eslint/js\` to match the upcoming \`eslint\` version in [Jenkins](https://jenkins2.eslint.org)
 - [ ] Verify if there are other packages (i.e., \`espree\`, \`eslint-scope\`, \`eslint-visitor-keys\`, \`@eslint/eslintrc\`) that need to be released first
+- [ ] Release \`@eslint/js\` to match the upcoming \`eslint\` version in [Jenkins](https://jenkins2.eslint.org)
 - [ ] Update \`package.json\` in the \`eslint\` repo with new versions from the preceding steps (create and merge a pull request)
 - [ ] Start the release on [Jenkins](https://jenkins2.eslint.org)
 - [ ] Update the release blog post:


### PR DESCRIPTION
As noted during the last release, it makes more sense to release `@eslint/js` after any other packages just before `eslint`, because `eslint` and `@eslint/js` should have the same version number.