### PR TITLE
chore: Upgrade to Node.js LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: 'lts/*'
       - name: Install dependencies
         run: npm install
       - name: Lint files
@@ -25,11 +25,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16.x]
+        node: [20.x]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "testEnvironment": "node"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
Dokku dropped support for Node.js 16, so it's time to upgrade (this is also causing the build to fail).

I'm not sure if we need to upgrade any dependencies to make things work, so running through CI as a first pass.