### PR TITLE
build: Pin to Node.js 16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "testEnvironment": "node"
   },
   "engines": {
-    "node": ">=16"
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
As a temporary measure to get us up and running again, I'm pinning our supported Node.js version to 16.x. I think this should get us deploying again until we can do #205 