### PR TITLE
refactor: remove unncessary `\b` flag to fix CI

### DIFF
--- a/src/plugins/issue-pr-link/index.js
+++ b/src/plugins/issue-pr-link/index.js
@@ -19,7 +19,7 @@
  * Regex to find issue references in PR bodies
  * Matches patterns like: "Fix #123", "Fixes #123", "Closes #123", "Resolves #123", etc.
  */
-const ISSUE_REFERENCE_REGEX = /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\b:?[ \t]+#(?<issueNumber>\d+)/giu;
+const ISSUE_REFERENCE_REGEX = /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved):?[ \t]+#(?<issueNumber>\d+)/giu;
 
 /**
  * Maximum number of issues to comment on per PR to prevent abuse
@@ -95,8 +95,8 @@ async function hasExistingComment(context, issueNumber, prNumber) {
             context.repo({ issue_number: issueNumber })
         );
 
-        const botComments = comments.filter(comment => 
-            comment.user.type === "Bot" && 
+        const botComments = comments.filter(comment =>
+            comment.user.type === "Bot" &&
             comment.body.includes("[//]: # (issue-pr-link)") &&
             comment.body.includes(`/pull/${prNumber}`)
         );
@@ -117,13 +117,13 @@ async function hasExistingComment(context, issueNumber, prNumber) {
 async function commentOnReferencedIssues(context) {
     const { payload } = context;
     const pr = payload.pull_request;
-    
+
     if (!pr || !pr.body) {
         return;
     }
 
     const issueNumbers = extractIssueNumbers(pr.body);
-    
+
     if (issueNumbers.length === 0) {
         return;
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

In this PR, I've removed the unnecessary `\b` flag to fix the CI.

Currently, the CI is failing in https://github.com/eslint/eslint-github-bot/actions/runs/17211670903/job/48824814786.

<img width="1549" height="308" alt="image" src="https://github.com/user-attachments/assets/a618387b-0a51-49f6-a049-f2be6bcb4f68" />

I believe this is because https://github.com/eslint/eslint-github-bot/pull/229 was merged first, and then https://github.com/eslint/eslint-github-bot/pull/226 was merged later without updating the branch, which caused the CI to fail.

#### What changes did you make? (Give an overview)

To resolve the issue above, I've removed the unnecessary `\b` flag as reported by `eslint-plugin-regexp`, which should fix the CI.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
