### PR TITLE
chore: remove unused `constants` file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,6 @@ The bot uses a plugin architecture with 6 core plugins in `src/plugins/`:
 ```
 src/
 ├── app.js                 # Main application entry point
-├── constants.js           # Shared constants (currently empty)
 └── plugins/
     ├── index.js          # Plugin exports
     ├── auto-assign/
@@ -132,7 +131,7 @@ tests/
 {
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix", 
+    "lint:fix": "npm run lint -- --fix",
     "start": "node ./src/app.js",
     "test": "jest --colors --verbose --coverage"
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,0 @@
-/**
- * @fileoverview Shared constants for the bot
- * @author Nicholas C. Zakas
- */
-
-"use strict";
-
-module.exports = {
-};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've removed the unused `constants` file.

After reviewing the entire codebase, it looks like the `constants` file isn't referenced anywhere, so I've decided to remove it.

According to the git history, the last time this file was used was about three years ago, so I think it's safe to delete it.

#### What changes did you make? (Give an overview)

In this PR, I've removed the unused `constants` file.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A