### PR TITLE
refactor: update outdated ESLint and OpenJS links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Please be sure to read the contribution guidelines before making or requesting a
 
 ## Code of Conduct
 
-This project adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct). We kindly request that you read over our code of conduct before contributing.
+This project adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct). We kindly request that you read over our code of conduct before contributing.
 
 ## Filing Issues
 
@@ -16,4 +16,4 @@ This project adheres to the [JS Foundation Code of Conduct](https://js.foundatio
 
 ## Contributing Code
 
-Please sign our [Contributor License Agreement](https://cla.js.foundation/eslint/eslint) and read over the [Pull Request Guidelines](https://eslint.org/docs/developer-guide/contributing/pull-requests).
+Please sign our [Contributor License Agreement](https://cla.openjsf.org/) and read over the [Pull Request Guidelines](https://eslint.org/docs/latest/contribute/pull-requests).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ This project adheres to the [OpenJS Foundation Code of Conduct](https://eslint.o
 
 ## Contributing Code
 
-Please sign our [Contributor License Agreement](https://cla.openjsf.org/) and read over the [Pull Request Guidelines](https://eslint.org/docs/latest/contribute/pull-requests).
+Please sign our [Contributor License Agreement](https://openjsf.org/cla) and read over the [Pull Request Guidelines](https://eslint.org/docs/latest/contribute/pull-requests).

--- a/docs/commit-message-check.md
+++ b/docs/commit-message-check.md
@@ -2,12 +2,12 @@
 
 ## Background
 
-`eslint-github-bot`'s commit message check ensures that all pull requests which get merged into `main` have a valid commit message, based on [ESLint's commit message guidelines](https://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes).
+`eslint-github-bot`'s commit message check ensures that all pull requests which get merged into `main` have a valid commit message, based on [ESLint's commit message guidelines](https://eslint.org/docs/latest/contribute/pull-requests#step-2-make-your-changes).
 
 The ESLint team uses GitHub's "Squash and Merge" feature to merge pull requests. When using this feature, the default commit message for the squashed commit is the title of the pull request. To minimize the risk of an incorrect commit message getting merged into `main`, `eslint-github-bot` checks the title.
 
 ## How do I fix it?
 
-If this status check is failing on your pull request, you should fix your pull request title on github.com to conform to [ESLint's commit message guidelines](https://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes).
+If this status check is failing on your pull request, you should fix your pull request title on github.com to conform to [ESLint's commit message guidelines](https://eslint.org/docs/latest/contribute/pull-requests#step-2-make-your-changes).
 
 ![](./edit-pr-title-explanation.png)

--- a/src/plugins/commit-message/createMessage.js
+++ b/src/plugins/commit-message/createMessage.js
@@ -41,6 +41,6 @@ ${errorMessages.join("\n")}
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 `;
 };

--- a/tests/plugins/commit-message/__snapshots__/index.test.js.snap
+++ b/tests/plugins/commit-message/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -24,7 +24,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -39,7 +39,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -54,7 +54,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -69,7 +69,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -84,7 +84,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -99,7 +99,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -114,7 +114,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -129,7 +129,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -144,7 +144,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -158,7 +158,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -172,7 +172,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -185,7 +185,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -200,7 +200,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -215,7 +215,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -230,7 +230,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -245,7 +245,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -260,7 +260,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -275,7 +275,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -290,7 +290,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -305,7 +305,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -319,7 +319,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -333,7 +333,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -346,7 +346,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -359,7 +359,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -373,7 +373,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -386,7 +386,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -400,7 +400,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -414,7 +414,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -429,7 +429,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -444,7 +444,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -459,7 +459,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -474,7 +474,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -489,7 +489,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -504,7 +504,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -519,7 +519,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -534,7 +534,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -548,7 +548,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -562,7 +562,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -575,7 +575,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -590,7 +590,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -605,7 +605,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -620,7 +620,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -635,7 +635,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -650,7 +650,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -665,7 +665,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -680,7 +680,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -695,7 +695,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -709,7 +709,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -723,7 +723,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -736,7 +736,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -749,7 +749,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -763,7 +763,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -776,7 +776,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -790,7 +790,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -804,7 +804,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -819,7 +819,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -834,7 +834,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -849,7 +849,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -864,7 +864,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -879,7 +879,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -894,7 +894,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -909,7 +909,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -924,7 +924,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -938,7 +938,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -952,7 +952,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -965,7 +965,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -980,7 +980,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -995,7 +995,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1010,7 +1010,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1025,7 +1025,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1040,7 +1040,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1055,7 +1055,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1070,7 +1070,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1085,7 +1085,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1099,7 +1099,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1113,7 +1113,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1126,7 +1126,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1139,7 +1139,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1153,7 +1153,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1166,7 +1166,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1180,7 +1180,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1194,7 +1194,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1209,7 +1209,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1224,7 +1224,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1239,7 +1239,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1254,7 +1254,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1269,7 +1269,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1284,7 +1284,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1299,7 +1299,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1314,7 +1314,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1328,7 +1328,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1342,7 +1342,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1355,7 +1355,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1370,7 +1370,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1385,7 +1385,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1400,7 +1400,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1415,7 +1415,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1430,7 +1430,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1445,7 +1445,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1460,7 +1460,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1475,7 +1475,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1489,7 +1489,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1503,7 +1503,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1516,7 +1516,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1529,7 +1529,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1543,7 +1543,7 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;
 
@@ -1556,6 +1556,6 @@ The **pull request title** isn't properly formatted. We ask that you update the 
 
 **To Fix:** You can fix this problem by clicking 'Edit' next to the pull request title at the top of this page.
 
-Read more about contributing to ESLint [here](https://eslint.org/docs/developer-guide/contributing/)
+Read more about contributing to ESLint [here](https://eslint.org/docs/latest/contribute/)
 "
 `;


### PR DESCRIPTION
<!--
    Thank you for contributing!
    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->
#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).
<!--
    Please ensure your pull request is ready:
    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->
<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
This repository still contains a few links that point to old domains and old documentation paths. They all respond with HTTP 200, so they appear to work, but following the redirects to their final destination reveals a defunct domain or a restructured docs path. This PR updates them to the URLs that `eslint/eslint` currently uses.

I verified each link's final destination by opening it directly in a browser.

#### What changes did you make? (Give an overview)
All three files are the same kind of link update, so I grouped them into a single PR. Happy to split it up if you'd prefer.

**1. `CONTRIBUTING.md`**
- Code of Conduct link: `https://js.foundation/community/code-of-conduct` → `https://eslint.org/conduct`
  (The old link redirects to the foundation homepage rather than the Code of Conduct document. The new link also redirects, but it lands on the actual document, and `eslint/eslint` uses this same link.)
- Also updated the link text from "JS Foundation" to "OpenJS Foundation".
- CLA link: `https://cla.js.foundation/eslint/eslint` → `https://cla.openjsf.org/`
- Pull Request Guidelines link: `.../docs/developer-guide/contributing/pull-requests` → `.../docs/latest/contribute/pull-requests`
  (The old link still resolves via redirect, but it uses the old domain and old docs path.)

**2. `docs/commit-message-check.md`**
- Updated two old docs-path links to `docs/latest/contribute/...` (the `#step-2-make-your-changes` still exists on the new page, so it was kept).

**3. `src/plugins/commit-message/createMessage.js`**
- Updated the link inside the comment message the bot posts on PRs to `docs/latest/contribute/`.

#### Related Issues
None

#### Is there anything you'd like reviewers to focus on?
- The change to `index.test.js.snap` (108 lines) is the regenerated output from `jest -u`, reflecting the updated link in `createMessage.js`. I reviewed the generated diff and confirmed that nothing other than the link string changed.
